### PR TITLE
feat: implement batch processing and rate limiting to avoid throttling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,7 +165,9 @@ Embedded in CloudFormation template:
 - Decodes base64-encoded Kafka messages
 - Constructs text payload: "At {timestamp} the price of {ticker} is {price}."
 - Generates UUID for each document
+- Batches up to 10 documents per API call (IngestKnowledgeBaseDocuments API limit: 10 documents/request)
 - Calls `ingest_knowledge_base_documents()` via `ingest_with_backoff()` helper with exponential backoff + jitter (retries on ThrottlingException, max 5 attempts)
+- Implements rate limiting with configurable inter-batch delay (`BATCH_DELAY` environment variable, default: 2.0 seconds) to proactively avoid throttling (API limit: 5 RPS)
 
 ### Required Environment Variables (Lambda)
 
@@ -173,6 +175,7 @@ Set automatically by `1.Setup.ipynb`:
 
 - `KBID`: Bedrock Knowledge Base ID
 - `DSID`: Custom Data Source ID
+- `BATCH_DELAY` (optional): Inter-batch delay in seconds to avoid API throttling. Default: 2.0. Can be tuned via Lambda environment variables without redeployment
 
 ### Bedrock Knowledge Base Configuration
 

--- a/docs/archive/plan.md
+++ b/docs/archive/plan.md
@@ -1,0 +1,368 @@
+# 実装計画: Lambda コードの 3 つの改善
+
+対象ファイル: `templates/bedrock-kb-stream-ingest.yml`（843〜932 行目、Lambda インラインコード）
+
+---
+
+## 変更 1: `datetime.utcfromtimestamp()` の置換
+
+### 背景
+
+`datetime.utcfromtimestamp()` は Python 3.12 で非推奨（DeprecationWarning）となり、将来のバージョンで削除される予定。naive な datetime オブジェクト（タイムゾーン情報なし）を返すため、タイムゾーンの取り扱いで混乱を招きやすい。
+
+参照: <https://docs.python.org/3.13/library/datetime.html#datetime.datetime.utcfromtimestamp>
+
+### 現在のコード（886 行目）
+
+```python
+payload_ts = datetime.utcfromtimestamp(timestamp).strftime('%Y-%m-%d %H:%M:%S')
+```
+
+### 変更後のコード
+
+```python
+payload_ts = datetime.fromtimestamp(timestamp, tz=timezone.utc).strftime('%Y-%m-%d %H:%M:%S')
+```
+
+### 必要な import の変更（851 行目）
+
+```python
+# 変更前
+from datetime import datetime
+
+# 変更後
+from datetime import datetime, timezone
+```
+
+### 動作への影響
+
+出力フォーマットは同一（`%Y-%m-%d %H:%M:%S`）。`fromtimestamp` に `tz=timezone.utc` を渡すことで aware な datetime オブジェクトが返されるが、`strftime` の出力文字列には差異がない。Bedrock KB に取り込まれるペイロード文字列は変わらない。
+
+---
+
+## 変更 2: `time.sleep(5)` を exponential backoff に置換
+
+### 背景
+
+現在は各レコードの `ingest_knowledge_base_documents()` 呼び出し前に一律 5 秒の sleep を入れている。API スロットリングへの簡易対策だが、以下の問題がある:
+
+- スロットリングが発生しない場合でも無条件に待機するため、17 レコードで約 85 秒の無駄な遅延が生じる
+- 実際にスロットリングが発生した場合、5 秒では不十分な可能性がある
+- レコード数に比例して処理時間が線形に増加する
+
+### 設計方針
+
+sleep を API 呼び出しの前ではなく、`ClientError`（ThrottlingException）発生時のリトライロジックに移動する。正常時は sleep なしで処理し、スロットリングが発生した場合のみ exponential backoff でリトライする。
+
+`ingest_knowledge_base_documents()` API のスロットリング例外は `ThrottlingException`（HTTP 429）。
+
+### 変更後のコード（概要）
+
+```python
+import random
+
+MAX_RETRIES = 5
+BASE_DELAY = 1.0
+MAX_DELAY = 30.0
+
+def ingest_with_backoff(client, kb_id, ds_id, documents):
+    for attempt in range(MAX_RETRIES):
+        try:
+            response = client.ingest_knowledge_base_documents(
+                knowledgeBaseId=kb_id,
+                dataSourceId=ds_id,
+                documents=documents
+            )
+            return response
+        except botocore.exceptions.ClientError as error:
+            error_code = error.response['Error']['Code']
+            if error_code == 'ThrottlingException' and attempt < MAX_RETRIES - 1:
+                delay = min(BASE_DELAY * (2 ** attempt) + random.uniform(0, 1), MAX_DELAY)
+                print(f'ThrottlingException, retrying in {delay:.1f}s (attempt {attempt + 1}/{MAX_RETRIES})')
+                time.sleep(delay)
+            else:
+                raise
+```
+
+### リトライパラメータの根拠
+
+| パラメータ | 値 | 根拠 |
+|-----------|-----|------|
+| MAX_RETRIES | 5 | AWS SDK のデフォルトリトライ回数に合わせる |
+| BASE_DELAY | 1.0 秒 | 初回リトライは軽く。元の 5 秒よりも短い |
+| MAX_DELAY | 30.0 秒 | Lambda タイムアウト 900 秒に対して十分な余裕を持つ |
+| ジッタ | 0〜1 秒のランダム加算 | 複数 Lambda インスタンスの同時リトライ衝突を回避（full jitter） |
+
+リトライ間隔の推移: 1〜2 秒 → 2〜3 秒 → 4〜5 秒 → 8〜9 秒 → 16〜17 秒（最大 5 回で合計約 31〜36 秒）。
+
+### `time.sleep(5)` の削除
+
+890 行目の `time.sleep(5)` を削除し、上記の `ingest_with_backoff()` 関数を呼び出すように変更する。正常時は sleep なしで即座に次のレコードを処理するため、17 レコードの処理時間は約 85 秒から数秒に短縮される。
+
+### CloudFormation ZipFile サイズへの影響
+
+`ingest_with_backoff()` 関数の追加で約 500 バイト増加。現在約 1,500 バイト → 約 2,000 バイト。ZipFile の上限 4,096 バイトに収まる。`random` モジュールの import を 1 行追加する。
+
+---
+
+## 変更 3: トピック名の動的取得
+
+### 背景
+
+現在は `event['records']['streamtopic-0']` でトピック名とパーティション番号がハードコードされている。MSK Lambda イベントの構造は以下の通り:
+
+```json
+{
+  "eventSource": "aws:kafka",
+  "records": {
+    "streamtopic-0": [
+      {
+        "topic": "streamtopic",
+        "partition": 0,
+        "offset": 15,
+        "timestamp": 1545084650987,
+        "value": "base64encodedvalue..."
+      }
+    ]
+  }
+}
+```
+
+`event['records']` の各キーは `{topic}-{partition}` 形式で、複数トピック・複数パーティションの場合は複数のキーが存在する。各レコード内にも `topic` フィールドがある。
+
+### 変更後のコード（872 行目付近）
+
+```python
+# 変更前
+records = event['records']['streamtopic-0']
+
+# 変更後
+for topic_partition, records in event['records'].items():
+    for rec in records:
+        # 既存の処理...
+```
+
+`event['records']` を `items()` でイテレートすることで、トピック名やパーティション番号に関係なくすべてのレコードを処理する。
+
+### インデントの変更
+
+既存の `for rec in records:` ループの本体を `for topic_partition, records in event['records'].items():` の内側にネストする必要がある。CloudFormation YAML 内のインラインコードなので、インデントの追加は YAML の構造に影響しない（`|` ブロックスカラー内）。
+
+### 動作への影響
+
+- 単一トピック・単一パーティションの現構成では動作は変わらない
+- 将来的にパーティション数を増やした場合（例: `streamtopic-0`, `streamtopic-1`）、すべてのパーティションのレコードを処理できる
+- 複数トピックのイベントソースマッピングを追加した場合も対応可能
+
+---
+
+## 変更の全体像
+
+3 つの変更はすべて `templates/bedrock-kb-stream-ingest.yml` の Lambda インラインコード（843〜932 行目）に対するもので、他のファイルへの変更は不要。
+
+### 変更後の Lambda コード全体
+
+```python
+import os
+import json
+import base64
+import logging
+import random
+import time
+import uuid
+from datetime import datetime, timezone
+
+import boto3
+import botocore
+from botocore.exceptions import ClientError
+
+bedrock_agent_client = boto3.client('bedrock-agent')
+
+MAX_RETRIES = 5
+BASE_DELAY = 1.0
+MAX_DELAY = 30.0
+
+def ingest_with_backoff(client, kb_id, ds_id, documents):
+    for attempt in range(MAX_RETRIES):
+        try:
+            response = client.ingest_knowledge_base_documents(
+                knowledgeBaseId=kb_id,
+                dataSourceId=ds_id,
+                documents=documents
+            )
+            return response
+        except botocore.exceptions.ClientError as error:
+            error_code = error.response['Error']['Code']
+            if error_code == 'ThrottlingException' and attempt < MAX_RETRIES - 1:
+                delay = min(BASE_DELAY * (2 ** attempt) + random.uniform(0, 1), MAX_DELAY)
+                print(f'ThrottlingException, retrying in {delay:.1f}s (attempt {attempt + 1}/{MAX_RETRIES})')
+                time.sleep(delay)
+            else:
+                raise
+
+def lambda_handler(event, context):
+    print(f'boto3 version: {boto3.__version__}')
+    print(f'botocore version: {botocore.__version__}')
+    print('## ENVIRONMENT VARIABLES')
+    print(os.environ['AWS_LAMBDA_LOG_GROUP_NAME'])
+    print(os.environ['AWS_LAMBDA_LOG_STREAM_NAME'])
+    kb_id = os.environ['KBID']
+    print(kb_id)
+    ds_id = os.environ['DSID']
+    print(ds_id)
+    print('## EVENT')
+    print(event)
+
+    for topic_partition, records in event['records'].items():
+        print(f'## PROCESSING: {topic_partition}')
+        for rec in records:
+            print('## RECORD')
+            event_payload = decode_payload(rec['value'])
+            print('Decoded event main', event_payload)
+            ticker = event_payload['ticker']
+            price = event_payload['price']
+            timestamp = event_payload['timestamp']
+            myuuid = uuid.uuid4()
+            print('## RECORD UUID', str(myuuid))
+            print('## TICKER: ', ticker)
+            print('## PRICE: ', price)
+            payload_ts = datetime.fromtimestamp(timestamp, tz=timezone.utc).strftime('%Y-%m-%d %H:%M:%S')
+            print('## TIMESTAMP: ', payload_ts)
+            payload_string = "At " + payload_ts + " the price of " + ticker + " is " + str(price) + "."
+            print('## PAYLOAD STRING: ', payload_string)
+            documents = [
+                {
+                    'content': {
+                        'custom': {
+                            'customDocumentIdentifier': {
+                                'id': str(myuuid)
+                            },
+                            'inlineContent': {
+                                'textContent': {
+                                    'data': payload_string
+                                },
+                                'type': 'TEXT'
+                            },
+                            'sourceType': 'IN_LINE'
+                        },
+                        'dataSourceType': 'CUSTOM'
+                    }
+                }
+            ]
+            response = ingest_with_backoff(bedrock_agent_client, kb_id, ds_id, documents)
+            print('## INGEST KNOWLEDGE BASE DOCUMENTS RESPONSE: ', response)
+
+    return {
+        'statusCode': 200,
+        'body': json.dumps('Success from Lambda!')
+    }
+
+def decode_payload(event_data):
+    print('Received event', event_data)
+    agg_data_bytes = base64.b64decode(event_data)
+    decoded_data = agg_data_bytes.decode(encoding="utf-8")
+    event_payload = json.loads(decoded_data)
+    print('Decoded event', event_payload)
+    logging.info(f'Decoded data from kafka topic: {event_payload}')
+    return event_payload
+```
+
+### コードサイズ見積もり
+
+変更後のコードは約 2,800 バイト。CloudFormation ZipFile の上限 4,096 バイト以内。
+
+---
+
+## テスト方針
+
+### 変更 1（datetime）の検証
+
+CloudWatch Logs でペイロード文字列の出力を確認し、タイムスタンプのフォーマットが `YYYY-MM-DD HH:MM:SS` であることを検証。
+
+### 変更 2（exponential backoff）の検証
+
+- 正常系: スロットリングが発生しない場合、sleep なしで処理が完了することを CloudWatch Logs の処理時間から確認（17 レコードが数秒で完了）
+- 異常系: Bedrock API の同時呼び出し等でスロットリングを意図的に発生させ、リトライログ（`ThrottlingException, retrying in ...`）が出力されることを確認
+
+### 変更 3（動的トピック名）の検証
+
+既存の `streamtopic` で動作確認。`event['records']` のキーが `streamtopic-0` であることを CloudWatch Logs で確認し、レコードが正常に処理されることを検証。
+
+---
+
+## 実装手順
+
+1. `templates/bedrock-kb-stream-ingest.yml` の Lambda インラインコード（843〜932 行目）を上記の変更後コードに置換
+2. CloudFormation スタックを更新（`aws cloudformation update-stack`）
+3. `2.StreamIngest.ipynb` でテストデータを送信し、CloudWatch Logs で動作を確認
+4. 処理時間の短縮（約 85 秒 → 数秒）を確認
+
+---
+
+## リスクと緩和策
+
+| リスク | 影響 | 緩和策 |
+|--------|------|--------|
+| ZipFile サイズ超過 | Lambda デプロイ失敗 | 事前にバイト数を計測。超過する場合は print 文を削減 |
+| exponential backoff で全リトライ失敗 | 一部レコードの取り込み漏れ | MAX_RETRIES=5 で十分なリトライ回数。失敗時は例外が raise され CloudWatch Logs に記録される |
+| 動的トピック名で予期しないキー形式 | レコード処理の失敗 | MSK イベントの `records` キーは AWS が `{topic}-{partition}` 形式で保証。`items()` はキー形式に依存しない |
+
+---
+
+## TODO リスト
+
+### Phase 1: 事前準備
+
+- [x] 1-1. 現在の Lambda インラインコード（`templates/bedrock-kb-stream-ingest.yml` 843〜932 行目）のバックアップとして git の現状をコミット済みであることを確認
+- [x] 1-2. 変更後コードのバイト数を計測し、ZipFile 上限 4,096 バイト以内であることを検証 → 3,764 バイト
+- [ ] 1-3. CloudFormation スタック `BedrockStreamIngest` が正常稼働中であることを確認 → スタック未稼働のためスキップ
+
+### Phase 2: コード変更（`templates/bedrock-kb-stream-ingest.yml`）
+
+- [x] 2-1. import 文の変更: `from datetime import datetime` → `from datetime import datetime, timezone`
+- [x] 2-2. import 文の追加: `import random`
+- [x] 2-3. `ingest_with_backoff()` 関数の追加（`lambda_handler` の前に配置）
+  - [x] 2-3a. リトライ定数の定義（MAX_RETRIES=5, BASE_DELAY=1.0, MAX_DELAY=30.0）
+  - [x] 2-3b. ThrottlingException 判定とリトライループの実装
+  - [x] 2-3c. exponential backoff + full jitter の delay 計算
+  - [x] 2-3d. リトライ時のログ出力（attempt 番号と待機秒数）
+- [x] 2-4. `lambda_handler` 内のトピック名の動的取得: `event['records']['streamtopic-0']` → `for topic_partition, records in event['records'].items():`
+  - [x] 2-4a. 外側ループ（`for topic_partition, records`）の追加
+  - [x] 2-4b. 既存の `for rec in records:` ループ本体のインデント調整（1 段深くネスト）
+  - [x] 2-4c. `topic_partition` のログ出力追加（`print(f'## PROCESSING: {topic_partition}')`)
+- [x] 2-5. `datetime.utcfromtimestamp(timestamp)` → `datetime.fromtimestamp(timestamp, tz=timezone.utc)` に置換
+- [x] 2-6. `time.sleep(5)` の削除
+- [x] 2-7. `ingest_knowledge_base_documents()` の直接呼び出しを `ingest_with_backoff()` 呼び出しに置換
+  - [x] 2-7a. documents リストを変数として API 呼び出しの前に定義
+  - [x] 2-7b. try/except ブロックを削除（`ingest_with_backoff` 内で処理するため）
+  - [x] 2-7c. レスポンスの print は `ingest_with_backoff` の戻り値で出力
+
+### Phase 3: コード検証（ローカル）
+
+- [x] 3-1. 変更後の YAML が有効な CloudFormation テンプレートであることを確認 → PyYAML + CFN loader で OK
+- [x] 3-2. Lambda インラインコード部分のインデント（YAML `|` ブロック内の Python インデント）が正しいことを目視確認
+- [x] 3-3. 変更後コードの ZipFile サイズが 4,096 バイト以内であることを最終確認 → 3,764 バイト
+- [x] 3-4. `git diff` で変更箇所が 3 つの改善のみであることを確認（意図しない変更がないこと）
+
+### Phase 4: デプロイ
+
+- [x] 4-1. CloudFormation スタックの更新実行 → 完了
+- [x] 4-2. スタック更新完了の待機 → 完了
+- [x] 4-3. Lambda 関数のコードが更新されていることを確認 → 完了
+
+### Phase 5: 動作検証
+
+- [x] 5-1. `2.StreamIngest.ipynb` で TestData.csv の 17 レコードを MSK に送信 → 完了
+- [x] 5-2. CloudWatch Logs で Lambda の実行ログを確認 → 完了
+  - [x] 5-2a. `## PROCESSING: streamtopic-0` のログが出力されていること（変更 3 の検証） → 確認済み
+  - [x] 5-2b. タイムスタンプが `YYYY-MM-DD HH:MM:SS` 形式であること（変更 1 の検証） → 確認済み（`2026-02-16 07:31:45`）
+  - [x] 5-2c. `time.sleep(5)` 由来の 5 秒待機がなく、処理時間が大幅に短縮されていること（変更 2 の検証） → 確認済み
+  - [x] 5-2d. 全 17 レコードの `## INGEST KNOWLEDGE BASE DOCUMENTS RESPONSE` が出力されていること → 確認済み（HTTP 202, status: STARTING, RetryAttempts: 0）
+- [x] 5-3. Bedrock Knowledge Base に 17 件のドキュメントが取り込まれていることを確認 → 確認済み
+
+### Phase 6: ドキュメント更新
+
+- [x] 6-1. `CLAUDE.md` の Lambda 関数関連の記述を更新（exponential backoff、動的トピック名の反映）
+- [x] 6-2. `docs/research.md` のセクション 3.5（Lambda 関数）とセクション 11, 13（制限事項）を更新
+- [x] 6-3. `docs/plan.md` の TODO リストを完了済みに更新
+- [ ] 6-4. 変更内容をコミット → ユーザーの指示を待つ

--- a/docs/msk-lambda-integration.md
+++ b/docs/msk-lambda-integration.md
@@ -1,0 +1,101 @@
+# MSK と Lambda の連携の仕組み
+
+本ドキュメントは、Amazon MSK（Managed Streaming for Apache Kafka）と AWS Lambda が Event Source Mapping を通じてどのように連携するかを記録したものである。本プロジェクト固有の設定についても併せて整理する。
+
+---
+
+## 1. 全体像: プル型のイベント駆動モデル
+
+MSK が Lambda を直接「キック」しているわけではない。Lambda 側の Event Source Mapping というコンポーネントが内部的に Kafka コンシューマーとして動作し、MSK のトピックをポーリングしている。
+
+処理の流れは以下のとおり。
+
+1. プロデューサーが MSK のトピックにメッセージを書き込む
+2. Event Source Mapping のポーラーがトピックパーティションからメッセージをプルする
+3. ポーラーがバッチを組み立て、Lambda 関数を同期的に Invoke する
+4. Lambda がバッチを正常に処理すると、ポーラーがオフセットをコミットし、次のバッチに進む
+
+SQS のような「プッシュ型」に見えるが、内部的にはポーリングベースのプルモデルである。
+
+---
+
+## 2. MSK のメッセージ保持
+
+Kafka はメッセージキュー（SQS など）とは異なるログベースのモデルを採用している。
+
+| 特性 | SQS | MSK (Kafka) |
+|------|-----|-------------|
+| メッセージの消費後 | 削除される | ログに残る（retention period まで） |
+| 消費の追跡 | Visibility Timeout | コンシューマーグループのオフセット |
+| デフォルト保持期間 | 4日（最大14日） | 7日（設定変更可能） |
+| 複数コンシューマー | メッセージは1回だけ配信 | 異なるコンシューマーグループが独立して読める |
+
+Kafka ではコンシューマー（Event Source Mapping）がどこまで読んだかをオフセットで追跡する。処理成功後にオフセットをコミットして先に進み、失敗時はオフセットを進めないことでリトライを実現する。
+
+---
+
+## 3. 失敗時のリトライ挙動
+
+MSK はストリームベースのイベントソース扱いであり、Lambda invocation が失敗した場合（関数エラー、タイムアウト等）、Event Source Mapping は以下のように動作する。
+
+### 3.1 デフォルトの挙動
+
+失敗したバッチに対してオフセットを進めず、同じバッチを繰り返し再試行する。デフォルトではリトライ回数に上限がなく、成功するまで（または手動で介入するまで）無限にリトライする。
+
+この間、該当パーティションの後続メッセージの処理はブロックされる。これは Kafka のパーティション内メッセージ順序を保証するための設計である。
+
+### 3.2 リトライを制御するパラメータ
+
+Event Source Mapping 作成時に以下のパラメータで挙動を制御できる。
+
+| パラメータ | 説明 | デフォルト値 |
+|-----------|------|-------------|
+| `MaximumRetryAttempts` | リトライの最大回数。-1 で無限、0 でリトライなし | -1（無限） |
+| `BisectBatchOnFunctionError` | 失敗時にバッチを半分に分割して原因レコードを絞り込む | false |
+| `MaximumRecordAgeInSeconds` | この秒数より古いレコードは処理をスキップする | -1（無制限） |
+| `OnFailure.Destination` | リトライを使い切った場合の送信先（SQS ARN または SNS ARN） | なし |
+
+### 3.3 リトライが続いた場合の影響
+
+リトライ中はそのパーティションのオフセットが進まないため、新しいメッセージも処理されない。パーティションが1つしかない場合はトピック全体の処理が停止する。
+
+対策としては以下が考えられる。
+
+- `MaximumRetryAttempts` を有限に設定し、`OnFailure` で DLQ（Dead Letter Queue）に失敗レコードを退避させる
+- `BisectBatchOnFunctionError` を有効にして、問題のあるレコードを特定する
+- CloudWatch メトリクス `IteratorAge` を監視して、処理遅延を検知する
+
+---
+
+## 4. 本プロジェクトの設定
+
+本プロジェクトの Event Source Mapping は `notebooks/1.Setup.ipynb` で以下のように作成している。
+
+```python
+lambda_client.create_event_source_mapping(
+    EventSourceArn=MSKClusterArn,
+    FunctionName=LambdaFunctionName,
+    StartingPosition='LATEST',
+    Enabled=True,
+    Topics=['streamtopic']
+)
+```
+
+| 設定項目 | 値 | 意味 |
+|---------|-----|------|
+| StartingPosition | `LATEST` | マッピング作成後に到着した新しいメッセージのみ処理 |
+| Topics | `streamtopic` | 1トピックのみ |
+| パーティション数 | 1 | `1.Setup.ipynb` で `PartitionCount=1` として作成 |
+| MaximumRetryAttempts | 未設定（デフォルト: 無限） | 失敗時は無限にリトライ |
+| BisectBatchOnFunctionError | 未設定（デフォルト: false） | バッチ分割なし |
+| OnFailure | 未設定 | DLQ なし |
+
+サンプルプロジェクトとして検証用途のため、リトライ制御やDLQは設定していない。本番環境に適用する場合は `MaximumRetryAttempts` と `OnFailure` の設定を検討すること。
+
+---
+
+## 5. 参考リンク
+
+- [Using Lambda with Amazon MSK](https://docs.aws.amazon.com/lambda/latest/dg/with-msk.html) — Lambda と MSK の連携に関する公式ドキュメント
+- [Lambda event source mapping](https://docs.aws.amazon.com/lambda/latest/dg/invocation-eventsourcemapping.html) — Event Source Mapping の概要と設定パラメータ
+- [Lambda reserved concurrency](https://docs.aws.amazon.com/lambda/latest/dg/configuration-concurrency.html) — 予約同時実行数の設定

--- a/docs/plan-avoid-throttling.md
+++ b/docs/plan-avoid-throttling.md
@@ -429,19 +429,19 @@ aws lambda update-function-configuration \
 
 ### Phase 4: コード検証（ローカル）
 
-- [ ] 4-1. 変更後の ZipFile コードサイズが 4,096 バイト以内であることを計測
-- [ ] 4-2. サイズ超過の場合: `decode_payload` 内の print 文削減、または `print(f'## EVENT records: {len(event["records"])}')` のような軽量ログに切り替えて再計測
-- [ ] 4-3. `git diff` で変更箇所が意図どおりであることを確認
-- [ ] 4-4. セクション 6.3「変更後の Lambda 関数コード（全体像）」と差分を突き合わせ、漏れがないことを確認
-- [ ] 4-5. Python インデントが YAML `|` ブロック内で正しいことを目視確認（12 スペースの YAML インデント + 12 スペースの Python インデント）
+- [x] 4-1. 変更後の ZipFile コードサイズが 4,096 バイト以内であることを計測 → 3,562 バイト（残り 534 バイト）
+- [x] 4-2. サイズ超過の場合: `decode_payload` 内の print 文削減、または `print(f'## EVENT records: {len(event["records"])}')` のような軽量ログに切り替えて再計測 → スキップ（サイズ超過なし）
+- [x] 4-3. `git diff` で変更箇所が意図どおりであることを確認
+- [x] 4-4. セクション 6.3「変更後の Lambda 関数コード（全体像）」と差分を突き合わせ、漏れがないことを確認 → 完全一致
+- [x] 4-5. Python インデントが YAML `|` ブロック内で正しいことを目視確認（12 スペースの YAML インデント + 12 スペースの Python インデント）
 
 ### Phase 5: ドキュメント更新
 
-- [ ] 5-1. `CLAUDE.md` の「Lambda Function Code」セクション（L156-L168）を更新:
-  - [ ] 5-1a. `Calls ingest_knowledge_base_documents()` の記述にバッチ処理の説明を追加（10 ドキュメント/API コール）
-  - [ ] 5-1b. バッチ間ディレイの説明を追加（`BATCH_DELAY` 環境変数、デフォルト 2.0 秒）
-  - [ ] 5-1c. IngestKnowledgeBaseDocuments API の制約を記載（10 ドキュメント/リクエスト、5 RPS）
-- [ ] 5-2. `CLAUDE.md` の「Required Environment Variables (Lambda)」セクション（L170-L175）に `BATCH_DELAY` を追加:
+- [x] 5-1. `CLAUDE.md` の「Lambda Function Code」セクション（L156-L168）を更新:
+  - [x] 5-1a. `Calls ingest_knowledge_base_documents()` の記述にバッチ処理の説明を追加（10 ドキュメント/API コール）
+  - [x] 5-1b. バッチ間ディレイの説明を追加（`BATCH_DELAY` 環境変数、デフォルト 2.0 秒）
+  - [x] 5-1c. IngestKnowledgeBaseDocuments API の制約を記載（10 ドキュメント/リクエスト、5 RPS）
+- [x] 5-2. `CLAUDE.md` の「Required Environment Variables (Lambda)」セクション（L170-L175）に `BATCH_DELAY` を追加:
   - `BATCH_DELAY`（optional）: バッチ間ディレイ秒数。デフォルト 2.0。環境変数で調整可能
 
 ### Phase 6: デプロイと動作検証

--- a/docs/plan-avoid-throttling.md
+++ b/docs/plan-avoid-throttling.md
@@ -1,0 +1,493 @@
+# 実装計画: Bedrock API スロットリング回避
+
+対象ファイル: `templates/bedrock-kb-stream-ingest.yml`（Lambda インラインコード、L844〜L946）
+
+---
+
+## 1. 現状の問題
+
+### 1.1 発生している事象
+
+Lambda 関数が MSK から受信したレコードを処理する際、Bedrock `ingest_knowledge_base_documents()` API に対して 1 件ずつ高速にリクエストを送信するため、ThrottlingException（Too Many Requests, HTTP 429）が発生する。
+
+### 1.2 現在の Lambda コードの処理フロー
+
+`templates/bedrock-kb-stream-ingest.yml` の Lambda 関数（L844-L946）は以下のように動作する。
+
+1. `event['records']` から全トピック-パーティションのレコードを取得
+2. レコードごとに 1 件ずつ `ingest_with_backoff()` を呼び出す
+3. 各呼び出しでは 1 ドキュメントだけを含む API リクエストを送信
+4. リクエスト間のディレイは一切なし
+
+MSK Event Source Mapping のデフォルト BatchSize は 100 のため、1 回の Lambda 呼び出しで最大 100 レコードが届き、100 回の連続 API 呼び出しが発生しうる。
+
+### 1.3 既存のスロットリング対策
+
+`ingest_with_backoff()` 関数（L864-L880）にリアクティブなリトライ機構がある。
+
+- 最大リトライ回数: 5
+- 指数バックオフ: `min(1.0 * 2^attempt + random(0,1), 30.0)` 秒
+- `ThrottlingException` のみ捕捉
+
+この機構は ThrottlingException が発生した後にリトライするリアクティブな対策であり、そもそもスロットリングを発生させないプロアクティブな対策が欠けている。
+
+---
+
+## 2. Bedrock API のレートリミット
+
+AWS 公式ドキュメントに基づくレートリミットは以下のとおり。
+
+| API | TPS 上限 | 1 リクエストあたりの最大ドキュメント数 | ペイロードサイズ上限 | 調整可否 |
+|-----|----------|--------------------------------------|---------------------|---------|
+| IngestKnowledgeBaseDocuments | 5 | 10 | 6 MB | 不可（Fixed） |
+
+追加の制約:
+
+- IngestKnowledgeBaseDocuments と DeleteKnowledgeBaseDocuments の同時実行リクエスト合計は 10 まで（アカウント・リージョン単位）
+- Lambda の ReservedConcurrentExecutions=1 のため、同時実行数の制約は本プロジェクトでは問題にならない
+
+出典:
+
+- [Amazon Bedrock endpoints and quotas](https://docs.aws.amazon.com/general/latest/gr/bedrock.html)
+- [IngestKnowledgeBaseDocuments API Reference](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_agent_IngestKnowledgeBaseDocuments.html)
+
+---
+
+## 3. 参照プロジェクトの実績データ
+
+別プロジェクト（`docs/plan-avoid-throttling-tmp.md`, `templates/bedrock-kb-stream-ingest-tmp.yml`）で同様のスロットリング対策を実施済み。そのチューニング結果を以下に示す。
+
+| BATCH_DELAY | 実効 RPS | 結果 |
+|-------------|----------|------|
+| 0.5 秒 | 2 TPS | 多数の TooManyRequests が発生 |
+| 1.0 秒 | 1 TPS | 頻度低下するが依然発生 |
+| 2.0 秒 | 0.5 TPS | スロットリング完全解消 |
+
+この結果から、ドキュメント上の 5 TPS 制限よりも実効的な上限はかなり低いことがわかる。API 側の内部処理（ベクトル埋め込み生成等）がボトルネックになっていると推測される。
+
+参照プロジェクトの設計判断で本プロジェクトに適用するもの:
+
+- `BATCH_SIZE = 10`（API の 1 リクエストあたり最大ドキュメント数に合わせる）
+- `BATCH_DELAY` を環境変数化し、デプロイなしにチューニング可能にする
+- デフォルト値は実績に基づき 2.0 秒
+- 不要な import の削除（`logging`, `from botocore.exceptions import ClientError`）は `feature/improve-lambda-code` ブランチで実施し、本ブランチにマージ後の前提とする
+
+---
+
+## 4. 改善戦略
+
+2 つの戦略を組み合わせる。
+
+### 戦略 A: バッチ処理（API 呼び出し回数の削減）
+
+1 回の呼び出しで最大 10 ドキュメントを処理できるため、現在 1 件ずつ送信しているものを 10 件ずつまとめることで API 呼び出し回数を約 1/10 に削減する。
+
+### 戦略 B: バッチ間ディレイ（プロアクティブなレート制御）
+
+バッチ間に適切なディレイを挿入してスロットリングを予防する。環境変数 `BATCH_DELAY` で調整可能にすることで、デプロイなしにチューニングできるようにする。
+
+- デフォルト: 2.0 秒（参照プロジェクトの実績に基づく）
+- 環境変数 `BATCH_DELAY` でオーバーライド可能
+
+### 効果の見積もり
+
+100 レコードが 1 回の Lambda 呼び出しで届いた場合の比較:
+
+| 指標 | 変更前 | 変更後 |
+|------|--------|--------|
+| API 呼び出し回数 | 100 回 | 10 回 |
+| 想定スループット | 制御なし → 即座にスロットリング | 0.5 TPS（2.0 秒間隔） |
+| 処理時間（正常時） | スロットリング + リトライで不安定 | 10 × 2.0 = 約 20 秒 + API 応答時間 |
+| ThrottlingException の発生頻度 | 高頻度 | ほぼゼロ（リトライ機構がフォールバック） |
+
+17 レコード（TestData.csv）の場合:
+
+| 指標 | 変更前 | 変更後 |
+|------|--------|--------|
+| API 呼び出し回数 | 17 回 | 2 回 |
+| 処理時間（正常時） | 数秒 + スロットリング遅延 | 約 2.0 秒（1 間隔） |
+
+---
+
+## 5. CloudFormation ZipFile サイズの制約
+
+Lambda インラインコードは CloudFormation の `ZipFile` プロパティで定義されており、上限は 4,096 バイト。
+
+現在のコードサイズ: 3,788 バイト（残り 308 バイト）
+
+バッチ化の実装にはコード追加が必要だが、以下のバイト削減策で相殺する。
+
+### 削減策 1: 冗長な print 文の集約
+
+1 レコードあたり 7 行の print を 1 行に集約する。`payload_string` には ticker、price、timestamp がすべて含まれているため、個別の出力は冗長。
+
+```python
+# 変更前（7 行、約 226 バイト）
+print('## RECORD')
+print('Decoded event main', event_payload)
+print('## RECORD UUID', str(myuuid))
+print('## TICKER: ', ticker)
+print('## PRICE: ', price)
+print('## TIMESTAMP: ', payload_ts)
+print('## PAYLOAD STRING: ', payload_string)
+
+# 変更後（1 行、約 46 バイト）
+print(f'## DOC {myuuid}: {payload_string}')
+```
+
+### 削減策 2: 未使用 import の削除（feature/improve-lambda-code ブランチで実施）
+
+以下の削除は `feature/improve-lambda-code` ブランチで行い、本ブランチにマージ後の前提とする。
+
+```python
+# 削除: 使用箇所なし（コードは botocore.exceptions.ClientError を直接参照）
+from botocore.exceptions import ClientError
+
+# 削除: decode_payload 内の logging.info() を print に置換
+import logging
+```
+
+### 削減策 3: 冗長な冒頭ログの整理
+
+```python
+# 変更前（5 行）
+print('## ENVIRONMENT VARIABLES')
+print(os.environ['AWS_LAMBDA_LOG_GROUP_NAME'])
+print(os.environ['AWS_LAMBDA_LOG_STREAM_NAME'])
+print(kb_id)
+print(ds_id)
+
+# 変更後（1 行）
+print(f'KBID: {kb_id}, DSID: {ds_id}, BATCH_DELAY: {BATCH_DELAY}')
+```
+
+変更後のサイズ見積もり: 約 3,600〜3,800 バイト（4,096 バイト以内）。実装後に正確な計測を行う。
+
+---
+
+## 6. 実装計画
+
+### 6.1 対象ファイル
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `templates/bedrock-kb-stream-ingest.yml` | Lambda 関数コード改修 |
+| `CLAUDE.md` | Lambda 関数の説明と環境変数セクションの更新 |
+
+### 6.2 Lambda 関数コードの変更
+
+#### 6.2.1 import の整理（feature/improve-lambda-code ブランチで実施）
+
+以下は `feature/improve-lambda-code` ブランチで実施済みの前提。本ブランチでは変更しない。
+
+```python
+# 削除対象（feature/improve-lambda-code ブランチ）
+import logging
+from botocore.exceptions import ClientError
+```
+
+#### 6.2.2 定数の追加
+
+```python
+BATCH_SIZE = 10
+BATCH_DELAY = float(os.environ.get('BATCH_DELAY', '2.0'))
+```
+
+- `BATCH_SIZE` は API の上限（10 ドキュメント/リクエスト）に合わせる
+- `BATCH_DELAY` は環境変数から取得し、デフォルト 2.0 秒（参照プロジェクトの実績値）
+
+#### 6.2.3 ingest_with_backoff() のシグネチャ維持
+
+本プロジェクトは ingest のみのため、参照プロジェクトの `_retry_on_throttle(func)` パターンは採用せず、既存の `ingest_with_backoff(client, kb_id, ds_id, documents)` シグネチャを維持する。変更は ThrottlingException 判定のみ（機能的変更なし）。
+
+#### 6.2.4 lambda_handler の処理フロー変更
+
+```
+変更前:
+  for each topic_partition:
+      for each record:
+          build 1 document → ingest_with_backoff(1 doc) → 次のレコードへ
+
+変更後:
+  Phase 1 - 収集:
+      for each topic_partition:
+          for each record:
+              all_documents リストに追加
+
+  Phase 2 - バッチ ingest:
+      for each batch of 10 in all_documents:
+          ingest_with_backoff(batch)
+          最終バッチ以外は time.sleep(BATCH_DELAY)
+```
+
+#### 6.2.5 decode_payload の簡素化（feature/improve-lambda-code ブランチで実施）
+
+`logging.info()` 行の削除は `feature/improve-lambda-code` ブランチで実施。本ブランチでは変更しない。
+
+#### 6.2.6 Lambda の Description 更新
+
+```yaml
+Description: "Kafka Consumer Lambda Function - v3 batch processing with rate limiting"
+```
+
+### 6.3 変更後の Lambda 関数コード（全体像）
+
+```python
+import os
+import json
+import base64
+import random
+import time
+import uuid
+from datetime import datetime, timezone
+
+import boto3
+import botocore
+
+bedrock_agent_client = boto3.client('bedrock-agent', region_name='us-east-1')
+
+MAX_RETRIES = 5
+BASE_DELAY = 1.0
+MAX_DELAY = 30.0
+BATCH_SIZE = 10
+BATCH_DELAY = float(os.environ.get('BATCH_DELAY', '2.0'))
+
+def ingest_with_backoff(client, kb_id, ds_id, documents):
+    for attempt in range(MAX_RETRIES):
+        try:
+            response = client.ingest_knowledge_base_documents(
+                knowledgeBaseId=kb_id,
+                dataSourceId=ds_id,
+                documents=documents
+            )
+            return response
+        except botocore.exceptions.ClientError as error:
+            error_code = error.response['Error']['Code']
+            if error_code == 'ThrottlingException' and attempt < MAX_RETRIES - 1:
+                delay = min(BASE_DELAY * (2 ** attempt) + random.uniform(0, 1), MAX_DELAY)
+                print(f'ThrottlingException, retrying in {delay:.1f}s (attempt {attempt + 1}/{MAX_RETRIES})')
+                time.sleep(delay)
+            else:
+                raise
+
+def lambda_handler(event, context):
+    print(f'boto3 version: {boto3.__version__}')
+    print(f'botocore version: {botocore.__version__}')
+    kb_id = os.environ['KBID']
+    ds_id = os.environ['DSID']
+    print(f'KBID: {kb_id}, DSID: {ds_id}, BATCH_DELAY: {BATCH_DELAY}')
+
+    all_documents = []
+    for topic_partition, records in event['records'].items():
+        print(f'## PROCESSING: {topic_partition}')
+        for rec in records:
+            event_payload = decode_payload(rec['value'])
+            ticker = event_payload['ticker']
+            price = event_payload['price']
+            timestamp = event_payload['timestamp']
+            myuuid = uuid.uuid4()
+            payload_ts = datetime.fromtimestamp(timestamp, tz=timezone.utc).strftime('%Y-%m-%d %H:%M:%S')
+            payload_string = "At " + payload_ts + " the price of " + ticker + " is " + str(price) + "."
+            print(f'## DOC {myuuid}: {payload_string}')
+            all_documents.append({
+                'content': {
+                    'custom': {
+                        'customDocumentIdentifier': {
+                            'id': str(myuuid)
+                        },
+                        'inlineContent': {
+                            'textContent': {
+                                'data': payload_string
+                            },
+                            'type': 'TEXT'
+                        },
+                        'sourceType': 'IN_LINE'
+                    },
+                    'dataSourceType': 'CUSTOM'
+                }
+            })
+
+    print(f'## TOTAL DOCUMENTS: {len(all_documents)}')
+
+    for i in range(0, len(all_documents), BATCH_SIZE):
+        batch = all_documents[i:i + BATCH_SIZE]
+        batch_num = i // BATCH_SIZE + 1
+        total_batches = (len(all_documents) + BATCH_SIZE - 1) // BATCH_SIZE
+        print(f'## INGESTING BATCH {batch_num}/{total_batches} ({len(batch)} docs)')
+        response = ingest_with_backoff(bedrock_agent_client, kb_id, ds_id, batch)
+        print(f'## BATCH RESPONSE: {response}')
+        if i + BATCH_SIZE < len(all_documents):
+            time.sleep(BATCH_DELAY)
+
+    return {'statusCode': 200, 'body': json.dumps('Success from Lambda!')}
+
+def decode_payload(event_data):
+    agg_data_bytes = base64.b64decode(event_data)
+    decoded_data = agg_data_bytes.decode(encoding="utf-8")
+    event_payload = json.loads(decoded_data)
+    return event_payload
+```
+
+### 6.4 CLAUDE.md の更新
+
+Lambda Function Code セクションに以下を追加:
+
+- バッチ処理の説明（10 ドキュメント/API コール）
+- バッチ間ディレイの説明（`BATCH_DELAY` 環境変数、デフォルト 2.0 秒）
+- IngestKnowledgeBaseDocuments API の制約（10 ドキュメント/リクエスト、5 RPS）
+
+Required Environment Variables セクションに `BATCH_DELAY`（optional、デフォルト 2.0）を追加。
+
+---
+
+## 7. BATCH_DELAY のチューニング
+
+デプロイ後にスロットリングの発生状況に応じて、Lambda の環境変数でディレイを調整できる。
+
+```bash
+aws lambda update-function-configuration \
+  --function-name BedrockStreamIngestKafkaConsumerLambdaFunction \
+  --environment "Variables={KBID=<KB_ID>,DSID=<DS_ID>,BATCH_DELAY=3.0}"
+```
+
+| BATCH_DELAY | 実効スループット | 用途 |
+|-------------|-----------------|------|
+| 1.0 秒 | 10 docs/sec | 高スループットが必要な場合（スロットリングリスクあり） |
+| 2.0 秒 | 5 docs/sec | デフォルト（参照プロジェクトで検証済み） |
+| 3.0 秒 | 3.3 docs/sec | 安全マージンを広げたい場合 |
+
+---
+
+## 8. リスクと緩和策
+
+| リスク | 影響 | 緩和策 |
+|--------|------|--------|
+| ZipFile サイズ超過 | Lambda デプロイ失敗 | 実装後にバイト数を計測。超過する場合は decode_payload の print を削減 |
+| バッチ内の 1 件が不正データの場合 | API エラー | API は各ドキュメントの成否をレスポンスで返すため、部分的な成功が可能。サンプルプロジェクトでは個別のエラーハンドリングは省略 |
+| BATCH_DELAY=2.0 でもスロットリング発生 | リトライ増加 | 環境変数で BATCH_DELAY を増やして対応。指数バックオフが第二防衛線 |
+
+---
+
+## 9. 検証方法
+
+1. 変更後のコードサイズが 4,096 バイト以内であることを計測で確認
+2. CloudFormation スタックを更新して Lambda 関数をデプロイ
+3. `notebooks/2.StreamIngest.ipynb` でテストデータ（17 レコード）を MSK に送信
+4. CloudWatch Logs で以下を確認:
+   - `BATCH_DELAY: 2.0` がログに出力されること
+   - `## TOTAL DOCUMENTS: 17` が出力されること
+   - `## INGESTING BATCH 1/2 (10 docs)` と `## INGESTING BATCH 2/2 (7 docs)` が出力されること
+   - ThrottlingException のリトライログが発生しないこと
+   - 正常終了（statusCode: 200）すること
+
+---
+
+## 10. TODO リスト
+
+全フェーズと個別タスクの一覧。チェックボックスで進捗を追跡する。
+
+### Phase 1: 事前準備
+
+- [x] 1-1. `feat/batch-processing-rate-limiting` ブランチにいることを確認
+- [x] 1-2. git の作業ツリーがクリーンであることを確認（untracked: plan-avoid-throttling.md, tmp files のみ）
+- [x] 1-3. 現在の ZipFile コードサイズを計測し、ベースラインとして記録（現状: 3,788 バイト、残り 308 バイト）
+
+### Phase 2: 前提作業（`feature/improve-lambda-code` ブランチ）
+
+- [x] 2-1. `feature/improve-lambda-code` ブランチに切り替え
+- [x] 2-2. `import logging` を削除（L849）
+- [x] 2-3. `from botocore.exceptions import ClientError` を削除（L856）
+- [x] 2-4. `decode_payload` 内の `logging.info(f'Decoded data from kafka topic: {event_payload}')` 行を削除（L945）
+- [x] 2-5. 変更をコミット → 34b4da6
+- [x] 2-6. `feat/batch-processing-rate-limiting` ブランチに切り替え
+- [x] 2-7. `feature/improve-lambda-code` の変更を本ブランチにマージ（fast-forward）
+- [x] 2-8. マージ後の ZipFile コードサイズを計測 → 3,661 バイト（127 バイト削減、残り 435 バイト）
+
+### Phase 3: コード変更（`templates/bedrock-kb-stream-ingest.yml`）
+
+- [x] 3-1. 定数 `BATCH_SIZE = 10` を `MAX_DELAY = 30.0` の後に追加
+- [x] 3-2. 定数 `BATCH_DELAY = float(os.environ.get('BATCH_DELAY', '2.0'))` を `BATCH_SIZE` の後に追加
+- [x] 3-3. `lambda_handler` 冒頭のログ出力を整理:
+  - [x] 3-3a. `print('## ENVIRONMENT VARIABLES')` を削除
+  - [x] 3-3b. `print(os.environ['AWS_LAMBDA_LOG_GROUP_NAME'])` を削除
+  - [x] 3-3c. `print(os.environ['AWS_LAMBDA_LOG_STREAM_NAME'])` を削除
+  - [x] 3-3d. `print(kb_id)` と `print(ds_id)` を `print(f'KBID: {kb_id}, DSID: {ds_id}, BATCH_DELAY: {BATCH_DELAY}')` に置換
+  - [x] 3-3e. `print('## EVENT')` と `print(event)` を削除
+- [x] 3-4. `lambda_handler` を 2 フェーズ構成に書き換え:
+  - [x] 3-4a. `all_documents = []` リストを初期化
+  - [x] 3-4b. レコードごとの冗長な print 文を 1 行に集約 → `print(f'## DOC {myuuid}: {payload_string}')`
+  - [x] 3-4c. ドキュメント構築を `all_documents.append(...)` に変更
+  - [x] 3-4d. `ingest_with_backoff()` の呼び出しをレコードループ内から削除
+  - [x] 3-4e. `print(f'## TOTAL DOCUMENTS: {len(all_documents)}')` を追加
+  - [x] 3-4f. バッチ処理ループを追加
+  - [x] 3-4g. バッチスライス実装
+  - [x] 3-4h. バッチ番号計算と進捗ログ実装
+  - [x] 3-4i. バッチ単位での `ingest_with_backoff()` 呼び出し実装
+  - [x] 3-4j. バッチレスポンスログ実装
+  - [x] 3-4k. 最終バッチ以外で `time.sleep(BATCH_DELAY)` を挿入
+- [x] 3-5. Lambda Description を v3 に更新
+
+### Phase 4: コード検証（ローカル）
+
+- [ ] 4-1. 変更後の ZipFile コードサイズが 4,096 バイト以内であることを計測
+- [ ] 4-2. サイズ超過の場合: `decode_payload` 内の print 文削減、または `print(f'## EVENT records: {len(event["records"])}')` のような軽量ログに切り替えて再計測
+- [ ] 4-3. `git diff` で変更箇所が意図どおりであることを確認
+- [ ] 4-4. セクション 6.3「変更後の Lambda 関数コード（全体像）」と差分を突き合わせ、漏れがないことを確認
+- [ ] 4-5. Python インデントが YAML `|` ブロック内で正しいことを目視確認（12 スペースの YAML インデント + 12 スペースの Python インデント）
+
+### Phase 5: ドキュメント更新
+
+- [ ] 5-1. `CLAUDE.md` の「Lambda Function Code」セクション（L156-L168）を更新:
+  - [ ] 5-1a. `Calls ingest_knowledge_base_documents()` の記述にバッチ処理の説明を追加（10 ドキュメント/API コール）
+  - [ ] 5-1b. バッチ間ディレイの説明を追加（`BATCH_DELAY` 環境変数、デフォルト 2.0 秒）
+  - [ ] 5-1c. IngestKnowledgeBaseDocuments API の制約を記載（10 ドキュメント/リクエスト、5 RPS）
+- [ ] 5-2. `CLAUDE.md` の「Required Environment Variables (Lambda)」セクション（L170-L175）に `BATCH_DELAY` を追加:
+  - `BATCH_DELAY`（optional）: バッチ間ディレイ秒数。デフォルト 2.0。環境変数で調整可能
+
+### Phase 6: デプロイと動作検証
+
+- [ ] 6-1. CloudFormation スタックを更新
+
+```bash
+aws cloudformation update-stack \
+  --stack-name BedrockStreamIngest \
+  --template-body file://templates/bedrock-kb-stream-ingest.yml \
+  --parameters ParameterKey=Boto3LayerArn,ParameterValue=<既存の ARN> \
+  --capabilities CAPABILITY_NAMED_IAM
+```
+
+- [ ] 6-2. スタック更新の完了を待機
+
+```bash
+aws cloudformation wait stack-update-complete --stack-name BedrockStreamIngest
+```
+
+- [ ] 6-3. Lambda 関数のコードが正しく更新されたことを確認（AWS コンソールまたは `aws lambda get-function`）
+- [ ] 6-4. `notebooks/2.StreamIngest.ipynb` を実行して TestData.csv の 17 レコードを MSK に送信
+- [ ] 6-5. CloudWatch Logs で Lambda の実行ログを確認:
+  - [ ] 6-5a. `BATCH_DELAY: 2.0` がログに出力されていること
+  - [ ] 6-5b. `## TOTAL DOCUMENTS: 17` が出力されていること
+  - [ ] 6-5c. `## INGESTING BATCH 1/2 (10 docs)` が出力されていること
+  - [ ] 6-5d. `## INGESTING BATCH 2/2 (7 docs)` が出力されていること
+  - [ ] 6-5e. ThrottlingException のリトライログが出力されていないこと
+  - [ ] 6-5f. 正常終了（statusCode: 200）していること
+- [ ] 6-6. Bedrock Knowledge Base に 17 件のドキュメントが取り込まれていることを確認
+
+### Phase 7: チューニング（必要に応じて）
+
+- [ ] 7-1. Bedrock マネジメントコンソールで TooManyRequests エラーの有無を確認
+- [ ] 7-2. スロットリングが発生している場合: Lambda 環境変数 `BATCH_DELAY` を増やして対応
+
+```bash
+aws lambda update-function-configuration \
+  --function-name BedrockStreamIngestKafkaConsumerLambdaFunction \
+  --environment "Variables={KBID=<KB_ID>,DSID=<DS_ID>,BATCH_DELAY=3.0}"
+```
+
+- [ ] 7-3. チューニング結果を本ドキュメントに追記（BATCH_DELAY 値と結果の対応表）
+
+### Phase 8: 完了確認
+
+- [ ] 8-1. 変更前後のスロットリング発生状況を比較し、改善を確認
+- [ ] 8-2. `docs/plan-avoid-throttling.md` の TODO リストを完了済みに更新
+- [ ] 8-3. 変更内容をコミット

--- a/docs/research.md
+++ b/docs/research.md
@@ -1,0 +1,477 @@
+# プロジェクト調査レポート: Sample Stream Ingest Amazon Bedrock Knowledge Base
+
+## 1. プロジェクト概要
+
+本プロジェクトは、Apache Kafka（Amazon MSK）からのストリーミングデータを Amazon Bedrock Knowledge Bases にリアルタイムで取り込むサンプル実装である。aws-samples として公開されており、MIT-0 ライセンスで提供されている。
+
+データパイプラインの流れは以下の通り:
+
+1. SageMaker Studio のノートブックから confluent-kafka Producer で MSK にメッセージを送信
+2. Lambda 関数が MSK のイベントソースマッピング経由でメッセージを消費
+3. Lambda が Bedrock Agent API (`ingest_knowledge_base_documents()`) を呼び出し、Knowledge Base にインラインテキストとしてデータを取り込む
+
+核心的なユースケースは「ストリーミングデータをリアルタイムで RAG（Retrieval-Augmented Generation）のナレッジベースに反映する」というもので、従来のバッチ取り込み（S3 経由の同期）では実現できない即時性を提供する。
+
+---
+
+## 2. ディレクトリ構成
+
+```
+.
+├── CLAUDE.md                     # Claude Code 用プロジェクト指示書
+├── CODE_OF_CONDUCT.md            # Amazon OSS 行動規範
+├── CONTRIBUTING.md               # コントリビューションガイド
+├── LICENSE                       # MIT-0 ライセンス
+├── README.md                     # 簡潔なプロジェクト説明
+├── .gitignore                    # .DS_Store, .vscode, .cursor, .claude, build を除外
+├── .python-version               # Python 3.13
+├── docs/
+│   └── cost-analysis-lambda-msk.md  # コスト分析ドキュメント
+├── notebooks/
+│   ├── 1.Setup.ipynb             # 環境構築ノートブック
+│   ├── 2.StreamIngest.ipynb      # ストリーム取り込みテスト
+│   ├── 3.Cleanup.ipynb           # リソースクリーンアップ
+│   └── TestData.csv              # テスト用株価データ（17 銘柄）
+├── scripts/
+│   └── build-boto3-layer.sh      # Lambda レイヤービルドスクリプト
+└── templates/
+    └── bedrock-kb-stream-ingest.yml  # CloudFormation テンプレート
+```
+
+ソースコードは Lambda 関数のインラインコード（CloudFormation テンプレート内に埋め込み）と Jupyter ノートブック内のセルで構成されており、独立した Python モジュールは存在しない。
+
+---
+
+## 3. インフラストラクチャ詳細（CloudFormation テンプレート）
+
+### 3.1 パラメータ
+
+テンプレートは 3 つのパラメータを受け取る:
+
+| パラメータ | デフォルト値 | 説明 |
+|-----------|-------------|------|
+| KnowledgeBaseName | BedrockStreamIngestKnowledgeBase | Bedrock KB の名前（手動作成時に使用） |
+| DataSourceName | BedrockStreamIngestKBCustomDS | カスタムデータソースの名前 |
+| Boto3LayerArn | （必須、デフォルトなし） | boto3 Lambda レイヤーの ARN |
+
+Bedrock Knowledge Base 自体は CloudFormation では作成されず、AWS コンソールから手動作成する設計になっている。これは Bedrock KB の CloudFormation サポートが限定的であること（特にカスタムデータソースの設定）が理由と考えられる。
+
+### 3.2 ネットワーク構成
+
+VPC CIDR `10.0.0.0/16` に 4 つのサブネットを配置:
+
+| サブネット | CIDR | AZ | 用途 |
+|-----------|------|-----|------|
+| PublicSubnet1 | 10.0.0.0/20 | AZ-0 | NAT Gateway 配置 |
+| PublicSubnet2 | 10.0.16.0/20 | AZ-1 | （冗長性用、現状未使用） |
+| PrivateSubnet1 | 10.0.128.0/20 | AZ-0 | MSK, Lambda, SageMaker |
+| PrivateSubnet2 | 10.0.144.0/20 | AZ-1 | MSK, Lambda, SageMaker |
+
+各サブネットは /20 で 4,094 ホスト分の IP アドレスを持つ。プライベートサブネットからのインターネットアクセスは NAT Gateway（PublicSubnet1 に配置）経由で提供される。
+
+NAT Gateway が必要な理由は、Lambda が Bedrock Agent API を呼び出す際にインターネットアクセスが必要なためである（Bedrock にはパブリックエンドポイントしかない）。
+
+### 3.3 セキュリティグループ
+
+3 つのセキュリティグループが定義されている:
+
+| SG | 用途 | インバウンド許可 | アウトバウンド許可 |
+|----|------|----------------|------------------|
+| MSKSecurityGroup | MSK クラスター | Lambda SG, SageMaker SG, 自己参照 | 全 IPv4/IPv6, Lambda SG, SageMaker SG, 自己参照 |
+| LambdaSecurityGroup | Lambda 関数 | MSK SG, SageMaker SG, 自己参照 | 全 IPv4/IPv6, MSK SG, SageMaker SG, 自己参照 |
+| SageMakerSecurityGroup | SageMaker Studio | Lambda SG, MSK SG, 自己参照 | 全 IPv4/IPv6, Lambda SG, MSK SG, 自己参照 |
+
+全プロトコル（`IpProtocol: -1`）で相互通信を許可しており、検証環境としては許容範囲だが、本番環境では Kafka ポート（9092/9094）に限定すべき。
+
+### 3.4 MSK クラスター
+
+| 項目 | 値 |
+|------|-----|
+| インスタンスタイプ | kafka.t3.small |
+| ブローカー数 | 2（2 AZ に 1 つずつ） |
+| Kafka バージョン | 3.8.x（AWS 推奨） |
+| ストレージ | EBS 5 GB/ブローカー |
+| 暗号化（転送中） | TLS_PLAINTEXT（混在モード） |
+| 暗号化（クラスタ内） | false |
+| クライアント認証 | Unauthenticated（無認証） |
+| モニタリング | DEFAULT レベル |
+| ブローカーログ | CloudWatch Logs（保持 7 日） |
+
+無認証かつ暗号化無効の構成は検証用途に限定される。本番環境では IAM 認証 + TLS が推奨される。
+
+### 3.5 Lambda 関数
+
+| 項目 | 値 |
+|------|-----|
+| ランタイム | Python 3.13 |
+| タイムアウト | 900 秒 |
+| 予約同時実行数 | 1 |
+| VPC | プライベートサブネット 1, 2 |
+| レイヤー | boto3 >= 1.42.46（パラメータで指定） |
+
+Lambda コードは CloudFormation の `ZipFile` プロパティでインライン定義されている。処理フロー:
+
+1. `event['records'].items()` で全トピック・パーティションを動的にイテレート
+2. 各レコードの `value` を base64 デコード → UTF-8 デコード → JSON パース
+3. ticker, price, timestamp を抽出
+4. `datetime.fromtimestamp(timestamp, tz=timezone.utc)` でタイムスタンプを変換
+5. "At {timestamp} the price of {ticker} is {price}." というテキストを生成
+6. UUID を生成し、`ingest_with_backoff()` 経由で `ingest_knowledge_base_documents()` を呼び出し、インラインテキストとして取り込み
+
+`ingest_with_backoff()` は ThrottlingException 発生時のみ exponential backoff（base 1 秒、最大 30 秒、full jitter、最大 5 回リトライ）で再試行する。正常時は sleep なしで即座に次のレコードを処理するため、17 レコードの処理は数秒で完了する。
+
+### 3.6 SageMaker Studio
+
+| 項目 | 値 |
+|------|-----|
+| ネットワークモード | VpcOnly |
+| 認証 | IAM |
+| デフォルト EBS | 5 GB（最大 50 GB） |
+| セキュリティグループ管理 | Customer |
+
+VpcOnly モードにより、SageMaker Studio はプライベートサブネット内に配置される。これにより MSK クラスターへの直接接続が可能になる一方、インターネットアクセス（pip install 等）に NAT Gateway が必要になる。
+
+### 3.7 IAM ロールとポリシー
+
+2 つの IAM ロールが定義されている:
+
+SageMakerExecutionRole には以下のポリシーがアタッチされている:
+
+- AWSLambda_ReadOnlyAccess（マネージドポリシー）
+- AmazonSageMakerFullAccess（マネージドポリシー）
+- IAM アクセス（ロール作成・削除・パス等）
+- CloudWatch Metrics / Logs
+- MSK アクセス（Topic Management API 含む: CreateTopic, ListTopics 等）
+- CloudFormation（DescribeStacks, DescribeStackResource）
+- S3 アクセス
+- Bedrock アクセス（KB 操作全般）
+- Lambda アクセス（イベントソースマッピング操作含む）
+
+LambdaExecutionRole には以下のポリシーがアタッチされている:
+
+- Bedrock アクセス（KB 操作全般）
+- MSK アクセス（Read のみ + kafka-cluster 権限）
+- CloudWatch Metrics / Logs
+- ENI アクセス（VPC Lambda に必要）
+
+### 3.8 CloudFormation 出力
+
+| 出力キー | 値 |
+|---------|-----|
+| StackName | スタック名 |
+| KnowledgeBaseName | KB 名（手動作成用） |
+| DataSourceName | データソース名（手動作成用） |
+| MSKClusterArn | MSK クラスター ARN |
+| LambdaFunctionName | Lambda 関数名 |
+| SageMakerExecutionRoleArn | SageMaker 実行ロール ARN |
+
+---
+
+## 4. ノートブック詳細分析
+
+### 4.1 Notebook 1: Setup（1.Setup.ipynb）
+
+14 セル構成。処理の流れ:
+
+1. boto3/botocore のインポート
+2. boto3 >= 1.42.46 へのアップグレード（MSK CreateTopic API に必要）
+3. スタック名 `BedrockStreamIngest` とトピック名 `streamtopic` の定数定義
+4. CloudFormation 出力から KBName, DSName を取得
+5. CloudFormation から MSK クラスター ARN を取得
+6. MSK `get_bootstrap_brokers` で接続文字列を取得
+7. MSK CreateTopic API で `streamtopic` を作成（パーティション 1、レプリケーション 2）
+8. MSK ListTopics API でトピック一覧を確認
+9. （手動）AWS コンソールで Bedrock KB を作成する手順（マークダウンセル）
+10. Bedrock `list_knowledge_bases` で KB ID を取得
+11. Bedrock `list_data_sources` でデータソース ID を取得
+12. Lambda 関数名を CloudFormation から取得
+13. Lambda の環境変数に KBID, DSID を設定し、検証
+14. MSK イベントソースマッピングを作成（StartingPosition: LATEST）し、有効化を待機（最大 3 時間、30 秒間隔）
+15. `%store` で全変数を永続化
+
+MSK Topic Management API（CreateTopic, ListTopics）は 2026 年 2 月に公開された比較的新しい API で、Kafka クライアントのインストールなしにトピックの作成・管理が可能になった。boto3 >= 1.42.46 が必要条件。
+
+### 4.2 Notebook 2: StreamIngest（2.StreamIngest.ipynb）
+
+5 セル構成。処理の流れ:
+
+1. `%store -r` で前ノートブックの変数を復元
+2. confluent-kafka 2.13.0 をインストール
+3. ライブラリのインポート（confluent_kafka.Producer, pandas 等）
+4. `put_to_topic()` 関数の定義: confluent-kafka Producer でメッセージを送信
+5. TestData.csv を読み込み、各行を MSK トピックに送信
+
+メッセージペイロードは JSON 形式:
+```json
+{
+  "ticker": "OOOO",
+  "price": "$44.50",
+  "timestamp": 1739712345.678
+}
+```
+
+confluent-kafka は librdkafka ベースの C 拡張ライブラリで、PyKafka（2021 年にアーカイブ済み）から移行されている。
+
+### 4.3 Notebook 3: Cleanup（3.Cleanup.ipynb）
+
+4 セル構成。処理の流れ:
+
+1. `%store -r` で変数を復元
+2. Lambda のイベントソースマッピング UUID を取得
+3. イベントソースマッピングを削除
+4. 削除完了を待機（最大 1 時間、30 秒間隔）
+
+CloudFormation スタックの削除はこのノートブックの範囲外で、別途 AWS CLI 等で実行する必要がある。イベントソースマッピングだけを先に削除するのは、スタック削除前に Lambda への MSK トリガーを確実に切断するためと考えられる。
+
+---
+
+## 5. スクリプト
+
+### 5.1 build-boto3-layer.sh
+
+Lambda レイヤー用の boto3 パッケージをビルドし、AWS Lambda にパブリッシュするシェルスクリプト。
+
+処理フロー:
+1. `build/layer/` ディレクトリを作成（既存があれば削除）
+2. `pip install --target ./python 'boto3>=1.42.46'` で python/ ディレクトリにインストール
+3. `zip -r boto3-layer.zip python/` で ZIP 化
+4. `aws lambda publish-layer-version` でレイヤーをパブリッシュ
+5. LayerVersionArn を出力（CloudFormation パラメータに使用）
+
+オプション引数:
+- `--profile`: AWS CLI プロファイル
+- `--region`: AWS リージョン
+- `--attach FUNCTION_NAME`: 既存 Lambda 関数にレイヤーをアタッチ
+
+S3 を使わず `fileb://` で直接アップロードする点が特徴的で、S3 バケットの事前作成が不要。
+
+---
+
+## 6. テストデータ
+
+TestData.csv は 17 行のテスト用株価データ。
+
+| 列 | 説明 | サンプル |
+|----|------|---------|
+| ticker | 架空の銘柄コード | OOOO, ZVZZT, ZNTRX 等 |
+| price | 株価（ドル表記） | $44.50, "$3,413.23" 等 |
+
+すべて架空の銘柄コード（Z で始まるものが多い。NYSE/NASDAQ のテスト用ティッカーシンボルに準拠していると推測される）。価格帯は $0.45 から $3,413.23 まで幅広い。
+
+---
+
+## 7. データフロー詳細
+
+端から端までのデータフローを追跡する:
+
+```
+TestData.csv
+  ↓ pandas.read_csv()
+DataFrame (ticker, price)
+  ↓ json.dumps({ ticker, price, timestamp })
+UTF-8 バイト列
+  ↓ confluent-kafka Producer.produce()
+MSK Kafka トピック (streamtopic, パーティション 0)
+  ↓ Lambda イベントソースマッピング (StartingPosition: LATEST)
+Lambda 関数
+  ↓ base64 デコード → UTF-8 デコード → JSON パース
+{ticker, price, timestamp}
+  ↓ テキスト整形
+"At 2026-02-15 10:30:00 the price of OOOO is $44.50."
+  ↓ bedrock_agent_client.ingest_knowledge_base_documents()
+Bedrock Knowledge Base (インラインテキスト、UUID 付き)
+  ↓ Titan Text Embeddings v2
+ベクトルストア (S3 Vectors)
+```
+
+Lambda が受け取る MSK イベントの構造は `event['records']['streamtopic-0']` で、トピック名とパーティション番号がハイフンで結合されたキーでアクセスする。各レコードの `value` は base64 エンコードされている（Lambda の MSK イベントソースマッピングの仕様）。
+
+---
+
+## 8. 技術的な設計判断
+
+### 8.1 Lambda インラインコード vs S3 デプロイ
+
+Lambda コードが CloudFormation の `ZipFile` でインライン定義されている。利点は CloudFormation テンプレート 1 ファイルで完結すること、欠点はコードサイズ制限（4,096 バイト）とテストの困難さ。現状のコードは約 1,500 バイト程度なので制限内。
+
+### 8.2 boto3 Lambda レイヤー
+
+Lambda ランタイムのデフォルト boto3 は MSK CreateTopic API をサポートしていない（古いバージョン）。カスタムレイヤーで boto3 >= 1.42.46 を提供することで:
+
+- ランタイムの pip install が不要（コールドスタート短縮）
+- 確定的なバージョン管理が可能
+- MSK Topic Management API が利用可能
+
+### 8.3 MSK Topic Management API の採用
+
+従来、MSK のトピック作成には Kafka Admin Client（Java/Python）が必要で、kafka-python や confluent-kafka のインストールとネットワーク設定が前提だった。2026 年 2 月に公開された MSK の Public API（CreateTopic, ListTopics 等）を採用することで、boto3 だけでトピック管理が可能になった。
+
+### 8.4 confluent-kafka への移行
+
+元は PyKafka を使用していたが、PyKafka は 2021 年 3 月にアーカイブされ最終リリースは 2018 年 9 月。confluent-kafka（v2.13.0）は librdkafka ベースで Kafka 3.9.x まで互換性がある。
+
+### 8.5 予約同時実行数 = 1
+
+1 トピック・1 パーティションの構成では、Lambda はパーティションごとにシーケンシャルにバッチを処理するため、実質的に 1 インスタンスで十分。予約同時実行数を 1 に設定することで、想定外のスケーリングを防止している。
+
+### 8.6 Bedrock KB の手動作成
+
+Bedrock Knowledge Base は CloudFormation テンプレートに含まれておらず、AWS コンソールから手動作成する。カスタムデータソースの CloudFormation 対応が限定的であることが理由と考えられる。ノートブック内で KB 名とデータソース名を CloudFormation 出力から取得し、コンソール操作時の値を一致させる仕組みになっている。
+
+---
+
+## 9. コスト分析の要約
+
+`docs/cost-analysis-lambda-msk.md` に詳細なコスト分析がある。主要なコスト項目:
+
+| リソース | 月額概算（24h 稼働） |
+|---------|---------------------|
+| MSK（kafka.t3.small x 2） | $32 |
+| NAT Gateway | $33 |
+| Elastic IP | $3.65 |
+| SageMaker Studio | $2 |
+| CloudWatch Logs | $0（Free Tier 内） |
+| Lambda | $0 |
+| Bedrock Embeddings API | 約 $0 |
+| ベクトルストア（S3 Vectors） | 約 $0（完全従量課金、検証規模では $0.01 未満） |
+| 合計 | 約 $71/月 |
+
+ベクトルストアには Amazon S3 Vectors（2025 年 12 月 GA）を採用している。最小課金要件や OCU の概念がなく完全従量課金のため、検証規模ではコストは事実上ゼロ。参考として OpenSearch Serverless は最小 4 OCU で $700+/月、Aurora pgvector は $30～60/月かかる。
+
+主なコスト要因は MSK ブローカー（$32/月）と NAT Gateway（$33/月）の固定費であり、使わない期間のスタック削除運用が最も効果的な削減策となる。
+
+代替アーキテクチャとして、SageMaker Studio を CloudShell + Producer Lambda に置換する案も分析されている。これにより NAT Gateway・Elastic IP を VPC Endpoint 1 つに置換でき、月額 $24 の削減が見込める。
+
+---
+
+## 10. ノートブック間のデータ受け渡し
+
+IPython の `%store` マジックを使って変数をノートブック間で永続化している。
+
+Notebook 1 で永続化される変数:
+- StackName, KafkaTopic, KBName, DSName
+- LambdaFunctionName, KBId, DSId
+- BootstrapBrokerString, MSKClusterArn
+
+Notebook 2, 3 では `%store -r` で復元。この仕組みは SageMaker Studio のカーネル間で動作するが、ローカル Jupyter でも IPython のストアが利用可能。
+
+---
+
+## 11. セキュリティ上の考慮事項
+
+### 11.1 検証環境として許容される点
+
+- MSK のクライアント認証が Unauthenticated（VPC 内なので外部からのアクセスは不可）
+- 暗号化が TLS_PLAINTEXT（混在モード、クラスタ内暗号化なし）
+- セキュリティグループが全プロトコル許可
+
+### 11.2 本番環境では対応が必要な点
+
+- MSK の IAM 認証有効化
+- TLS のみ（PLAINTEXT 無効化）
+- セキュリティグループのポート制限（9094 for TLS）
+- ~~Lambda コード内の `datetime.utcfromtimestamp()` は Python 3.12 以降で非推奨~~ → 対応済み: `datetime.fromtimestamp(timestamp, tz=timezone.utc)` に置換
+- Bedrock 関連の IAM ポリシーが `Resource: '*'` で広範すぎる。KB ID やデータソース ID で絞るのが望ましい
+- ~~Lambda コード内の `time.sleep(5)` はレート制限対策だが、exponential backoff の方が堅牢~~ → 対応済み: `ingest_with_backoff()` で exponential backoff + jitter を実装
+
+---
+
+## 12. 依存関係
+
+### 12.1 ランタイム依存
+
+| コンポーネント | 依存 | バージョン |
+|--------------|------|-----------|
+| Lambda 関数 | boto3, botocore | >= 1.42.46（レイヤー） |
+| Lambda ランタイム | Python | 3.13 |
+| Notebook 1 | boto3 | >= 1.42.46 |
+| Notebook 2 | confluent-kafka | 2.13.0 |
+| Notebook 2 | pandas | （SageMaker Studio プリインストール） |
+| ビルドスクリプト | AWS CLI | v2 |
+| ビルドスクリプト | pip, zip | OS 標準 |
+
+### 12.2 AWS サービス依存
+
+- Amazon MSK（Kafka 3.8.x）
+- AWS Lambda（Python 3.13）
+- Amazon Bedrock（Knowledge Base, Agent API）
+- Amazon SageMaker Studio
+- AWS CloudFormation
+- Amazon VPC（NAT Gateway, EIP 含む）
+- Amazon CloudWatch Logs
+- AWS IAM
+
+---
+
+## 13. 制限事項と改善候補
+
+### 13.1 現在の制限
+
+- Bedrock KB がテンプレート外（手動作成）のため、完全な IaC ではない
+- ~~Lambda コード内のトピック名 `streamtopic-0` がハードコードされている~~ → 対応済み: `event['records'].items()` で動的取得
+- ~~`time.sleep(5)` による固定遅延は、レコード数が増えると処理時間が線形に増加する~~ → 対応済み: exponential backoff に置換
+- テストデータの price 列がドル記号付き文字列のため、Lambda 側では数値変換せずそのまま文字列として取り込まれる
+- エラーハンドリングが最小限（ThrottlingException のリトライは対応済み、それ以外は re-raise）
+
+### 13.2 改善候補
+
+- CloudFormation に `AWS::Bedrock::KnowledgeBase` リソースを追加（対応状況次第）
+- ~~Lambda コードのトピック名をイベント構造から動的に取得~~ → 対応済み
+- バッチ処理の実装（`ingest_knowledge_base_documents()` は最大 10 ドキュメントまで対応可能）
+- ~~Exponential backoff の実装（`time.sleep(5)` の置換）~~ → 対応済み
+- CloudFormation の Bedrock IAM ポリシーをリソース ARN で制限
+- MSK の IAM 認証有効化と TLS 強制
+
+---
+
+## 14. 実行手順の全体フロー
+
+```
+[事前準備]
+  ./scripts/build-boto3-layer.sh
+  → Boto3LayerArn を取得
+
+[CloudFormation デプロイ]
+  aws cloudformation create-stack ... --parameters Boto3LayerArn=...
+  → 20-30 分待機（MSK クラスター作成）
+
+[SageMaker Studio でノートブック実行]
+  1.Setup.ipynb
+    → boto3 アップグレード
+    → MSK トピック作成（CreateTopic API）
+    → AWS コンソールで Bedrock KB 手動作成
+    → Lambda 環境変数設定
+    → MSK イベントソースマッピング作成
+
+  2.StreamIngest.ipynb
+    → confluent-kafka インストール
+    → TestData.csv の 17 レコードを MSK に送信
+    → Lambda が自動起動 → Bedrock KB にインジェスト
+
+  3.Cleanup.ipynb
+    → イベントソースマッピング削除
+
+[スタック削除]
+  aws cloudformation delete-stack --stack-name BedrockStreamIngest
+  → 20-30 分待機
+```
+
+---
+
+## 15. まとめ
+
+本プロジェクトは、Amazon Bedrock Knowledge Bases の `ingest_knowledge_base_documents()` API を使ったストリーミングデータのリアルタイム取り込みを実証するサンプル実装である。
+
+技術的な特徴:
+- MSK + Lambda のイベント駆動アーキテクチャでリアルタイムパイプラインを構築
+- MSK Topic Management API（2026 年 2 月公開）の採用により Kafka クライアント不要でトピック管理が可能
+- Lambda レイヤーによる boto3 バージョン管理でコールドスタートを最小化
+- confluent-kafka による堅牢な Kafka Producer 実装
+
+アーキテクチャ上の特性:
+- CloudFormation 1 テンプレートでインフラの大部分を管理（Bedrock KB を除く）
+- SageMaker Studio の VpcOnly モードで MSK への直接接続を実現
+- 検証用途に特化した構成（無認証 MSK、広範な IAM ポリシー、全プロトコル許可の SG）
+- コスト最適化の詳細分析と代替アーキテクチャの検討が文書化されている
+
+本サンプルは「動くデモ」として完成度が高く、ストリーミング → RAG のパイプラインを理解するための教材として有用である。本番環境への適用にはセキュリティ強化（MSK 認証、TLS、IAM ポリシーの絞り込み）と運用面の改善（エラーハンドリング、バッチ処理、モニタリング）が必要になる。

--- a/templates/bedrock-kb-stream-ingest.yml
+++ b/templates/bedrock-kb-stream-ingest.yml
@@ -821,7 +821,7 @@ Resources:
       - LambdaBedrockAccessPolicy
     Properties:
       FunctionName: !Sub "${AWS::StackName}KafkaConsumerLambdaFunction"
-      Description: "Kafka Consumer Lambda Function - v2 exponential backoff, dynamic topic, tz-aware datetime"
+      Description: "Kafka Consumer Lambda Function - v3 batch processing with rate limiting"
       ReservedConcurrentExecutions: 1
       Handler: index.lambda_handler
       Role: !GetAtt LambdaExecutionRole.Arn
@@ -858,6 +858,8 @@ Resources:
             MAX_RETRIES = 5
             BASE_DELAY = 1.0
             MAX_DELAY = 30.0
+            BATCH_SIZE = 10
+            BATCH_DELAY = float(os.environ.get('BATCH_DELAY', '2.0'))
 
             def ingest_with_backoff(client, kb_id, ds_id, documents):
                 for attempt in range(MAX_RETRIES):
@@ -880,66 +882,58 @@ Resources:
             def lambda_handler(event, context):
                 print(f'boto3 version: {boto3.__version__}')
                 print(f'botocore version: {botocore.__version__}')
-                print('## ENVIRONMENT VARIABLES')
-                print(os.environ['AWS_LAMBDA_LOG_GROUP_NAME'])
-                print(os.environ['AWS_LAMBDA_LOG_STREAM_NAME'])
                 kb_id = os.environ['KBID']
-                print(kb_id)
                 ds_id = os.environ['DSID']
-                print(ds_id)
-                print('## EVENT')
-                print(event)
+                print(f'KBID: {kb_id}, DSID: {ds_id}, BATCH_DELAY: {BATCH_DELAY}')
 
+                all_documents = []
                 for topic_partition, records in event['records'].items():
                     print(f'## PROCESSING: {topic_partition}')
                     for rec in records:
-                        print('## RECORD')
                         event_payload = decode_payload(rec['value'])
-                        print('Decoded event main', event_payload)
                         ticker = event_payload['ticker']
                         price = event_payload['price']
                         timestamp = event_payload['timestamp']
                         myuuid = uuid.uuid4()
-                        print('## RECORD UUID', str(myuuid))
-                        print('## TICKER: ', ticker)
-                        print('## PRICE: ', price)
                         payload_ts = datetime.fromtimestamp(timestamp, tz=timezone.utc).strftime('%Y-%m-%d %H:%M:%S')
-                        print('## TIMESTAMP: ', payload_ts)
                         payload_string = "At " + payload_ts + " the price of " + ticker + " is " + str(price) + "."
-                        print('## PAYLOAD STRING: ', payload_string)
-                        documents = [
-                            {
-                                'content': {
-                                    'custom' : {
-                                        'customDocumentIdentifier': {
-                                            'id' : str(myuuid)
-                                        },
-                                        'inlineContent' : {
-                                            'textContent' : {
-                                                'data' : payload_string
-                                            },
-                                            'type' : 'TEXT'
-                                        },
-                                        'sourceType' : 'IN_LINE'
+                        print(f'## DOC {myuuid}: {payload_string}')
+                        all_documents.append({
+                            'content': {
+                                'custom': {
+                                    'customDocumentIdentifier': {
+                                        'id': str(myuuid)
                                     },
-                                    'dataSourceType' : 'CUSTOM'
-                                }
+                                    'inlineContent': {
+                                        'textContent': {
+                                            'data': payload_string
+                                        },
+                                        'type': 'TEXT'
+                                    },
+                                    'sourceType': 'IN_LINE'
+                                },
+                                'dataSourceType': 'CUSTOM'
                             }
-                        ]
-                        response = ingest_with_backoff(bedrock_agent_client, kb_id, ds_id, documents)
-                        print('## INGEST KNOWLEDGE BASE DOCUMENTS RESPONSE: ', response)
+                        })
 
-                return {
-                    'statusCode': 200,
-                    'body': json.dumps('Success from Lambda!')
-                }
+                print(f'## TOTAL DOCUMENTS: {len(all_documents)}')
+
+                for i in range(0, len(all_documents), BATCH_SIZE):
+                    batch = all_documents[i:i + BATCH_SIZE]
+                    batch_num = i // BATCH_SIZE + 1
+                    total_batches = (len(all_documents) + BATCH_SIZE - 1) // BATCH_SIZE
+                    print(f'## INGESTING BATCH {batch_num}/{total_batches} ({len(batch)} docs)')
+                    response = ingest_with_backoff(bedrock_agent_client, kb_id, ds_id, batch)
+                    print(f'## BATCH RESPONSE: {response}')
+                    if i + BATCH_SIZE < len(all_documents):
+                        time.sleep(BATCH_DELAY)
+
+                return {'statusCode': 200, 'body': json.dumps('Success from Lambda!')}
 
             def decode_payload(event_data):
-                print('Received event', event_data)
                 agg_data_bytes = base64.b64decode(event_data)
                 decoded_data = agg_data_bytes.decode(encoding="utf-8")
                 event_payload = json.loads(decoded_data)
-                print('Decoded event', event_payload)
                 return event_payload
           - Region: !Ref AWS::Region
 

--- a/templates/bedrock-kb-stream-ingest.yml
+++ b/templates/bedrock-kb-stream-ingest.yml
@@ -845,7 +845,6 @@ Resources:
             import os
             import json
             import base64
-            import logging
             import random
             import time
             import uuid
@@ -853,7 +852,6 @@ Resources:
 
             import boto3
             import botocore
-            from botocore.exceptions import ClientError
 
             bedrock_agent_client = boto3.client('bedrock-agent', region_name='us-east-1')
 
@@ -942,7 +940,6 @@ Resources:
                 decoded_data = agg_data_bytes.decode(encoding="utf-8")
                 event_payload = json.loads(decoded_data)
                 print('Decoded event', event_payload)
-                logging.info(f'Decoded data from kafka topic: {event_payload}')
                 return event_payload
           - Region: !Ref AWS::Region
 

--- a/templates/bedrock-kb-stream-ingest.yml
+++ b/templates/bedrock-kb-stream-ingest.yml
@@ -1,7 +1,7 @@
 # Amazon Bedrock Knowledge Base - Stream Ingest Data
 
-AWSTemplateFormatVersion: '2010-09-09'
-Description: 'Template to create required resources to showcase how streaming data can be directly ingested into Amazon Bedrock Knowledge Base'
+AWSTemplateFormatVersion: "2010-09-09"
+Description: "Template to create required resources to showcase how streaming data can be directly ingested into Amazon Bedrock Knowledge Base"
 
 # Parameters
 Parameters:
@@ -28,33 +28,32 @@ Parameters:
 Mappings:
   SubnetConfig:
     VPC:
-      CIDR: '10.0.0.0/16'
+      CIDR: "10.0.0.0/16"
     PublicSubnet1:
-      CIDR: '10.0.0.0/20'
+      CIDR: "10.0.0.0/20"
     PublicSubnet2:
-      CIDR: '10.0.16.0/20'
+      CIDR: "10.0.16.0/20"
     PrivateSubnet1:
-      CIDR: '10.0.128.0/20'
+      CIDR: "10.0.128.0/20"
     PrivateSubnet2:
-      CIDR: '10.0.144.0/20'
+      CIDR: "10.0.144.0/20"
 
 # Resources
 Resources:
-
-# VPC
+  # VPC
 
   VPC:
     Type: AWS::EC2::VPC
     Properties:
-      CidrBlock: !FindInMap ['SubnetConfig', 'VPC', 'CIDR']
+      CidrBlock: !FindInMap ["SubnetConfig", "VPC", "CIDR"]
       EnableDnsHostnames: true
       EnableDnsSupport: true
       InstanceTenancy: default
       Tags:
-        - Key: 'Name'
-          Value: !Join [ "", [ !Ref "AWS::StackName","VPC" ] ]
+        - Key: "Name"
+          Value: !Join ["", [!Ref "AWS::StackName", "VPC"]]
 
-# Subnets
+  # Subnets
 
   PublicSubnet1:
     Type: AWS::EC2::Subnet
@@ -63,13 +62,13 @@ Resources:
       AvailabilityZone:
         Fn::Select:
           - 0
-          - Fn::GetAZs: {Ref: 'AWS::Region'}
-      VpcId: !Ref 'VPC'
-      CidrBlock: !FindInMap ['SubnetConfig', 'PublicSubnet1', 'CIDR']
+          - Fn::GetAZs: { Ref: "AWS::Region" }
+      VpcId: !Ref "VPC"
+      CidrBlock: !FindInMap ["SubnetConfig", "PublicSubnet1", "CIDR"]
       MapPublicIpOnLaunch: false
       Tags:
-        - Key: 'Name'
-          Value: !Join [ "", [ !Ref "AWS::StackName","PublicSubnet1" ] ]
+        - Key: "Name"
+          Value: !Join ["", [!Ref "AWS::StackName", "PublicSubnet1"]]
 
   PublicSubnet2:
     Type: AWS::EC2::Subnet
@@ -78,13 +77,13 @@ Resources:
       AvailabilityZone:
         Fn::Select:
           - 1
-          - Fn::GetAZs: {Ref: 'AWS::Region'}
-      VpcId: !Ref 'VPC'
-      CidrBlock: !FindInMap ['SubnetConfig', 'PublicSubnet2', 'CIDR']
+          - Fn::GetAZs: { Ref: "AWS::Region" }
+      VpcId: !Ref "VPC"
+      CidrBlock: !FindInMap ["SubnetConfig", "PublicSubnet2", "CIDR"]
       MapPublicIpOnLaunch: false
       Tags:
-        - Key: 'Name'
-          Value: !Join [ "", [ !Ref "AWS::StackName","PublicSubnet2" ] ]
+        - Key: "Name"
+          Value: !Join ["", [!Ref "AWS::StackName", "PublicSubnet2"]]
 
   PrivateSubnet1:
     Type: AWS::EC2::Subnet
@@ -92,13 +91,13 @@ Resources:
       AvailabilityZone:
         Fn::Select:
           - 0
-          - Fn::GetAZs: {Ref: 'AWS::Region'}
-      VpcId: !Ref 'VPC'
-      CidrBlock: !FindInMap ['SubnetConfig', 'PrivateSubnet1', 'CIDR']
+          - Fn::GetAZs: { Ref: "AWS::Region" }
+      VpcId: !Ref "VPC"
+      CidrBlock: !FindInMap ["SubnetConfig", "PrivateSubnet1", "CIDR"]
       MapPublicIpOnLaunch: false
       Tags:
-        - Key: 'Name'
-          Value: !Join [ "", [ !Ref "AWS::StackName","PrivateSubnet1" ] ]
+        - Key: "Name"
+          Value: !Join ["", [!Ref "AWS::StackName", "PrivateSubnet1"]]
 
   PrivateSubnet2:
     Type: AWS::EC2::Subnet
@@ -106,30 +105,30 @@ Resources:
       AvailabilityZone:
         Fn::Select:
           - 1
-          - Fn::GetAZs: {Ref: 'AWS::Region'}
-      VpcId: !Ref 'VPC'
-      CidrBlock: !FindInMap ['SubnetConfig', 'PrivateSubnet2', 'CIDR']
+          - Fn::GetAZs: { Ref: "AWS::Region" }
+      VpcId: !Ref "VPC"
+      CidrBlock: !FindInMap ["SubnetConfig", "PrivateSubnet2", "CIDR"]
       MapPublicIpOnLaunch: false
       Tags:
-        - Key: 'Name'
-          Value: !Join [ "", [ !Ref "AWS::StackName","PrivateSubnet2" ] ]
+        - Key: "Name"
+          Value: !Join ["", [!Ref "AWS::StackName", "PrivateSubnet2"]]
 
-# Internet Gateway
+  # Internet Gateway
 
   InternetGateway:
     Type: AWS::EC2::InternetGateway
     Properties:
       Tags:
         - Key: Name
-          Value: !Join [ "", [ !Ref "AWS::StackName","InternetGateway" ] ]
+          Value: !Join ["", [!Ref "AWS::StackName", "InternetGateway"]]
 
   InternetGatewayAttachment:
     Type: AWS::EC2::VPCGatewayAttachment
     Properties:
-      VpcId: !Ref 'VPC'
-      InternetGatewayId: !Ref 'InternetGateway'
+      VpcId: !Ref "VPC"
+      InternetGatewayId: !Ref "InternetGateway"
 
-# Elastic IP
+  # Elastic IP
 
   ElasticIPAddress:
     Type: AWS::EC2::EIP
@@ -137,115 +136,115 @@ Resources:
       Domain: vpc
       Tags:
         - Key: Name
-          Value: !Join [ "", [ !Ref "AWS::StackName","ElasticIP" ] ]
+          Value: !Join ["", [!Ref "AWS::StackName", "ElasticIP"]]
 
-# NAT Gateway
+  # NAT Gateway
 
   NATGateway:
     Type: AWS::EC2::NatGateway
     Properties:
       AllocationId: !GetAtt ElasticIPAddress.AllocationId
-      SubnetId: !Ref 'PublicSubnet1'
+      SubnetId: !Ref "PublicSubnet1"
       Tags:
-        - Key: 'Name'
-          Value: !Join [ "", [ !Ref "AWS::StackName","NATGateway" ] ]
+        - Key: "Name"
+          Value: !Join ["", [!Ref "AWS::StackName", "NATGateway"]]
 
-# Public Routes
+  # Public Routes
 
   PublicRouteTable:
     Type: AWS::EC2::RouteTable
     Properties:
-      VpcId: !Ref 'VPC'
+      VpcId: !Ref "VPC"
       Tags:
-        - Key: 'Name'
-          Value: !Join [ "", [ !Ref "AWS::StackName","PublicRouteTable" ] ]
+        - Key: "Name"
+          Value: !Join ["", [!Ref "AWS::StackName", "PublicRouteTable"]]
 
   PublicRoute:
     Type: AWS::EC2::Route
     Properties:
-      RouteTableId: !Ref 'PublicRouteTable'
-      DestinationCidrBlock: '0.0.0.0/0'
-      GatewayId: !Ref 'InternetGateway'
+      RouteTableId: !Ref "PublicRouteTable"
+      DestinationCidrBlock: "0.0.0.0/0"
+      GatewayId: !Ref "InternetGateway"
 
   PublicSubnet1RouteTableAssociation:
     Type: AWS::EC2::SubnetRouteTableAssociation
     Properties:
-      SubnetId: !Ref 'PublicSubnet1'
-      RouteTableId: !Ref 'PublicRouteTable'
+      SubnetId: !Ref "PublicSubnet1"
+      RouteTableId: !Ref "PublicRouteTable"
 
   PublicSubnet2RouteTableAssociation:
     Type: AWS::EC2::SubnetRouteTableAssociation
     Properties:
-      SubnetId: !Ref 'PublicSubnet2'
-      RouteTableId: !Ref 'PublicRouteTable'
+      SubnetId: !Ref "PublicSubnet2"
+      RouteTableId: !Ref "PublicRouteTable"
 
-# Private Routes
+  # Private Routes
 
   PrivateRouteTable:
     Type: AWS::EC2::RouteTable
     Properties:
-      VpcId: !Ref 'VPC'
+      VpcId: !Ref "VPC"
       Tags:
-        - Key: 'Name'
-          Value: !Join [ "", [ !Ref "AWS::StackName","PrivateRouteTable" ] ]
+        - Key: "Name"
+          Value: !Join ["", [!Ref "AWS::StackName", "PrivateRouteTable"]]
 
   PrivateRoute:
     Type: AWS::EC2::Route
     Properties:
-      RouteTableId: !Ref 'PrivateRouteTable'
-      DestinationCidrBlock: '0.0.0.0/0'
-      GatewayId: !Ref 'NATGateway'
+      RouteTableId: !Ref "PrivateRouteTable"
+      DestinationCidrBlock: "0.0.0.0/0"
+      GatewayId: !Ref "NATGateway"
 
   PrivateSubnet1RouteTableAssociation:
     Type: AWS::EC2::SubnetRouteTableAssociation
     Properties:
-      SubnetId: !Ref 'PrivateSubnet1'
-      RouteTableId: !Ref 'PrivateRouteTable'
+      SubnetId: !Ref "PrivateSubnet1"
+      RouteTableId: !Ref "PrivateRouteTable"
 
   PrivateSubnet2RouteTableAssociation:
     Type: AWS::EC2::SubnetRouteTableAssociation
     Properties:
-      SubnetId: !Ref 'PrivateSubnet2'
-      RouteTableId: !Ref 'PrivateRouteTable'
+      SubnetId: !Ref "PrivateSubnet2"
+      RouteTableId: !Ref "PrivateRouteTable"
 
-# Security Groups
+  # Security Groups
 
   MSKSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
-      VpcId: !Ref 'VPC'
-      GroupName: !Sub '${AWS::StackName}MSKSecurityGroup'
-      GroupDescription: 'MSK Security Group'
+      VpcId: !Ref "VPC"
+      GroupName: !Sub "${AWS::StackName}MSKSecurityGroup"
+      GroupDescription: "MSK Security Group"
       Tags:
-        - Key: 'Name'
-          Value: !Join [ "", [ !Ref "AWS::StackName","MSKSecurityGroup" ] ]
+        - Key: "Name"
+          Value: !Join ["", [!Ref "AWS::StackName", "MSKSecurityGroup"]]
 
   LambdaSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
-      VpcId: !Ref 'VPC'
-      GroupName: !Sub '${AWS::StackName}LambdaSecurityGroup'
-      GroupDescription: 'Lambda Security Group'
+      VpcId: !Ref "VPC"
+      GroupName: !Sub "${AWS::StackName}LambdaSecurityGroup"
+      GroupDescription: "Lambda Security Group"
       Tags:
-        - Key: 'Name'
-          Value: !Join [ "", [ !Ref "AWS::StackName","LambdaSecurityGroup" ] ]
+        - Key: "Name"
+          Value: !Join ["", [!Ref "AWS::StackName", "LambdaSecurityGroup"]]
 
   SageMakerSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
-      VpcId: !Ref 'VPC'
-      GroupName: !Sub '${AWS::StackName}SageMakerSecurityGroup'
-      GroupDescription: 'SageMaker Security Group'
+      VpcId: !Ref "VPC"
+      GroupName: !Sub "${AWS::StackName}SageMakerSecurityGroup"
+      GroupDescription: "SageMaker Security Group"
       Tags:
-        - Key: 'Name'
-          Value: !Join [ "", [ !Ref "AWS::StackName","SageMakerSecurityGroup" ] ]
+        - Key: "Name"
+          Value: !Join ["", [!Ref "AWS::StackName", "SageMakerSecurityGroup"]]
 
-# Security Group Ingress Rules
+  # Security Group Ingress Rules
 
   MSKSecurityGroupLambdaIngress:
     Type: AWS::EC2::SecurityGroupIngress
     Properties:
-      Description: 'Allow traffic from Lambda'
+      Description: "Allow traffic from Lambda"
       IpProtocol: -1
       SourceSecurityGroupId: !GetAtt LambdaSecurityGroup.GroupId
       GroupId: !Ref MSKSecurityGroup
@@ -253,7 +252,7 @@ Resources:
   MSKSecurityGroupSageMakerIngress:
     Type: AWS::EC2::SecurityGroupIngress
     Properties:
-      Description: 'Allow traffic from SageMaker'
+      Description: "Allow traffic from SageMaker"
       IpProtocol: -1
       SourceSecurityGroupId: !GetAtt SageMakerSecurityGroup.GroupId
       GroupId: !Ref MSKSecurityGroup
@@ -261,7 +260,7 @@ Resources:
   MSKSecurityGroupSelfIngress:
     Type: AWS::EC2::SecurityGroupIngress
     Properties:
-      Description: 'Allow traffic from within'
+      Description: "Allow traffic from within"
       IpProtocol: -1
       SourceSecurityGroupId: !GetAtt MSKSecurityGroup.GroupId
       GroupId: !Ref MSKSecurityGroup
@@ -269,7 +268,7 @@ Resources:
   LambdaSecurityGroupMSKIngress:
     Type: AWS::EC2::SecurityGroupIngress
     Properties:
-      Description: 'Allow traffic from MSK'
+      Description: "Allow traffic from MSK"
       IpProtocol: -1
       SourceSecurityGroupId: !GetAtt MSKSecurityGroup.GroupId
       GroupId: !Ref LambdaSecurityGroup
@@ -277,7 +276,7 @@ Resources:
   LambdaSecurityGroupSageMakerIngress:
     Type: AWS::EC2::SecurityGroupIngress
     Properties:
-      Description: 'Allow traffic from SageMaker'
+      Description: "Allow traffic from SageMaker"
       IpProtocol: -1
       SourceSecurityGroupId: !GetAtt SageMakerSecurityGroup.GroupId
       GroupId: !Ref LambdaSecurityGroup
@@ -285,7 +284,7 @@ Resources:
   LambdaSecurityGroupSelfIngress:
     Type: AWS::EC2::SecurityGroupIngress
     Properties:
-      Description: 'Allow traffic from within'
+      Description: "Allow traffic from within"
       IpProtocol: -1
       SourceSecurityGroupId: !GetAtt LambdaSecurityGroup.GroupId
       GroupId: !Ref LambdaSecurityGroup
@@ -293,7 +292,7 @@ Resources:
   SageMakerSecurityGroupLambdaIngress:
     Type: AWS::EC2::SecurityGroupIngress
     Properties:
-      Description: 'Allow traffic from Lambda'
+      Description: "Allow traffic from Lambda"
       IpProtocol: -1
       SourceSecurityGroupId: !GetAtt LambdaSecurityGroup.GroupId
       GroupId: !Ref SageMakerSecurityGroup
@@ -301,7 +300,7 @@ Resources:
   SageMakerSecurityGroupMSKIngress:
     Type: AWS::EC2::SecurityGroupIngress
     Properties:
-      Description: 'Allow traffic from MSK'
+      Description: "Allow traffic from MSK"
       IpProtocol: -1
       SourceSecurityGroupId: !GetAtt MSKSecurityGroup.GroupId
       GroupId: !Ref SageMakerSecurityGroup
@@ -309,33 +308,33 @@ Resources:
   SageMakerSecurityGroupSelfIngress:
     Type: AWS::EC2::SecurityGroupIngress
     Properties:
-      Description: 'Allow traffic from within'
+      Description: "Allow traffic from within"
       IpProtocol: -1
       SourceSecurityGroupId: !GetAtt SageMakerSecurityGroup.GroupId
       GroupId: !Ref SageMakerSecurityGroup
 
-# Security Group Egress Rules
+  # Security Group Egress Rules
 
   MSKSecurityGroupAllIPv4TrafficEgress:
     Type: AWS::EC2::SecurityGroupEgress
     Properties:
-      Description: 'Allow all ipv4 egress traffic'
+      Description: "Allow all ipv4 egress traffic"
       IpProtocol: -1
-      CidrIp: '0.0.0.0/0'
+      CidrIp: "0.0.0.0/0"
       GroupId: !Ref MSKSecurityGroup
 
   MSKSecurityGroupAllIPv6TrafficEgress:
     Type: AWS::EC2::SecurityGroupEgress
     Properties:
-      Description: 'Allow all ipv4 egress traffic'
+      Description: "Allow all ipv4 egress traffic"
       IpProtocol: -1
-      CidrIpv6: '::/0'
+      CidrIpv6: "::/0"
       GroupId: !Ref MSKSecurityGroup
 
   MSKSecurityGroupLambdaEgress:
     Type: AWS::EC2::SecurityGroupEgress
     Properties:
-      Description: 'Allow egress traffic to Lambda'
+      Description: "Allow egress traffic to Lambda"
       IpProtocol: -1
       DestinationSecurityGroupId: !GetAtt LambdaSecurityGroup.GroupId
       GroupId: !Ref MSKSecurityGroup
@@ -343,7 +342,7 @@ Resources:
   MSKSecurityGroupSageMakerEgress:
     Type: AWS::EC2::SecurityGroupEgress
     Properties:
-      Description: 'Allow egress traffic to SageMaker'
+      Description: "Allow egress traffic to SageMaker"
       IpProtocol: -1
       DestinationSecurityGroupId: !GetAtt SageMakerSecurityGroup.GroupId
       GroupId: !Ref MSKSecurityGroup
@@ -351,7 +350,7 @@ Resources:
   MSKSecurityGroupSelfEgress:
     Type: AWS::EC2::SecurityGroupEgress
     Properties:
-      Description: 'Allow egress traffic to within'
+      Description: "Allow egress traffic to within"
       IpProtocol: -1
       DestinationSecurityGroupId: !GetAtt MSKSecurityGroup.GroupId
       GroupId: !Ref MSKSecurityGroup
@@ -359,23 +358,23 @@ Resources:
   LambdaSecurityGroupAllIPv4TrafficEgress:
     Type: AWS::EC2::SecurityGroupEgress
     Properties:
-      Description: 'Allow all ipv4 egress traffic'
+      Description: "Allow all ipv4 egress traffic"
       IpProtocol: -1
-      CidrIp: '0.0.0.0/0'
+      CidrIp: "0.0.0.0/0"
       GroupId: !Ref LambdaSecurityGroup
 
   LambdaSecurityGroupAllIPv6TrafficEgress:
     Type: AWS::EC2::SecurityGroupEgress
     Properties:
-      Description: 'Allow all ipv4 egress traffic'
+      Description: "Allow all ipv4 egress traffic"
       IpProtocol: -1
-      CidrIpv6: '::/0'
+      CidrIpv6: "::/0"
       GroupId: !Ref LambdaSecurityGroup
 
   LambdaSecurityGroupMSKEgress:
     Type: AWS::EC2::SecurityGroupEgress
     Properties:
-      Description: 'Allow egress traffic to MSK'
+      Description: "Allow egress traffic to MSK"
       IpProtocol: -1
       DestinationSecurityGroupId: !GetAtt MSKSecurityGroup.GroupId
       GroupId: !Ref LambdaSecurityGroup
@@ -383,7 +382,7 @@ Resources:
   LambdaSecurityGroupSageMakerEgress:
     Type: AWS::EC2::SecurityGroupEgress
     Properties:
-      Description: 'Allow egress traffic to SageMaker'
+      Description: "Allow egress traffic to SageMaker"
       IpProtocol: -1
       DestinationSecurityGroupId: !GetAtt SageMakerSecurityGroup.GroupId
       GroupId: !Ref LambdaSecurityGroup
@@ -391,7 +390,7 @@ Resources:
   LambdaSecurityGroupSelfEgress:
     Type: AWS::EC2::SecurityGroupEgress
     Properties:
-      Description: 'Allow egress traffic to within'
+      Description: "Allow egress traffic to within"
       IpProtocol: -1
       DestinationSecurityGroupId: !GetAtt LambdaSecurityGroup.GroupId
       GroupId: !Ref LambdaSecurityGroup
@@ -399,7 +398,7 @@ Resources:
   SageMakerSecurityGroupLambdaEgress:
     Type: AWS::EC2::SecurityGroupEgress
     Properties:
-      Description: 'Allow egress traffic to Lambda'
+      Description: "Allow egress traffic to Lambda"
       IpProtocol: -1
       DestinationSecurityGroupId: !GetAtt LambdaSecurityGroup.GroupId
       GroupId: !Ref SageMakerSecurityGroup
@@ -407,7 +406,7 @@ Resources:
   SageMakerSecurityGroupMSKEgress:
     Type: AWS::EC2::SecurityGroupEgress
     Properties:
-      Description: 'Allow egress traffic to MSK'
+      Description: "Allow egress traffic to MSK"
       IpProtocol: -1
       DestinationSecurityGroupId: !GetAtt MSKSecurityGroup.GroupId
       GroupId: !Ref SageMakerSecurityGroup
@@ -415,7 +414,7 @@ Resources:
   SageMakerSecurityGroupSelfEgress:
     Type: AWS::EC2::SecurityGroupEgress
     Properties:
-      Description: 'Allow egress traffic to within'
+      Description: "Allow egress traffic to within"
       IpProtocol: -1
       DestinationSecurityGroupId: !GetAtt SageMakerSecurityGroup.GroupId
       GroupId: !Ref SageMakerSecurityGroup
@@ -423,26 +422,26 @@ Resources:
   SageMakerSecurityGroupAllIPv4TrafficEgress:
     Type: AWS::EC2::SecurityGroupEgress
     Properties:
-      Description: 'Allow all ipv4 egress traffic'
+      Description: "Allow all ipv4 egress traffic"
       IpProtocol: -1
-      CidrIp: '0.0.0.0/0'
+      CidrIp: "0.0.0.0/0"
       GroupId: !Ref SageMakerSecurityGroup
 
   SageMakerSecurityGroupAllIPv6TrafficEgress:
     Type: AWS::EC2::SecurityGroupEgress
     Properties:
-      Description: 'Allow all ipv4 egress traffic'
+      Description: "Allow all ipv4 egress traffic"
       IpProtocol: -1
-      CidrIpv6: '::/0'
+      CidrIpv6: "::/0"
       GroupId: !Ref SageMakerSecurityGroup
 
-# IAM Roles and Policies
+  # IAM Roles and Policies
 
   SageMakerExecutionRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub '${AWS::StackName}SageMakerExecutionRole'
-      Description: 'SageMaker Execution Role'
+      RoleName: !Sub "${AWS::StackName}SageMakerExecutionRole"
+      Description: "SageMaker Execution Role"
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -457,13 +456,13 @@ Resources:
         - arn:aws:iam::aws:policy/AWSLambda_ReadOnlyAccess
         - arn:aws:iam::aws:policy/AmazonSageMakerFullAccess
       Tags:
-        - Key: 'Name'
-          Value: !Join [ "", [ !Ref "AWS::StackName","SageMakerExecutionRole" ] ]
+        - Key: "Name"
+          Value: !Join ["", [!Ref "AWS::StackName", "SageMakerExecutionRole"]]
 
   SageMakerIAMAccessPolicy:
     Type: AWS::IAM::Policy
     Properties:
-      PolicyName: !Sub '${AWS::StackName}SageMakerIAMAccessPolicy'
+      PolicyName: !Sub "${AWS::StackName}SageMakerIAMAccessPolicy"
       PolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -480,14 +479,14 @@ Resources:
               - iam:GetRole
               - iam:GetRolePolicy
               - iam:SimulatePrincipalPolicy
-            Resource: !Sub 'arn:aws:iam::${AWS::AccountId}:*'
+            Resource: !Sub "arn:aws:iam::${AWS::AccountId}:*"
       Roles:
-        - Ref: 'SageMakerExecutionRole'
+        - Ref: "SageMakerExecutionRole"
 
   SageMakerCloudWatchMetricsAccessPolicy:
     Type: AWS::IAM::Policy
     Properties:
-      PolicyName: !Sub '${AWS::StackName}SageMakerCloudWatchMetricsAccessPolicy'
+      PolicyName: !Sub "${AWS::StackName}SageMakerCloudWatchMetricsAccessPolicy"
       PolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -500,14 +499,14 @@ Resources:
               - cloudwatch:ListMetrics
               - cloudwatch:PutMetricAlarm
               - cloudwatch:PutMetricData
-            Resource: '*'
+            Resource: "*"
       Roles:
         - Ref: "SageMakerExecutionRole"
 
   SageMakerCloudWatchLogsAccessPolicy:
     Type: AWS::IAM::Policy
     Properties:
-      PolicyName: !Sub '${AWS::StackName}SageMakerCloudWatchLogsAccessPolicy'
+      PolicyName: !Sub "${AWS::StackName}SageMakerCloudWatchLogsAccessPolicy"
       PolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -526,14 +525,14 @@ Resources:
               - logs:ListLogDeliveries
               - logs:PutResourcePolicy
               - logs:UpdateLogDelivery
-            Resource: 'arn:aws:logs:*:*:*'
+            Resource: "arn:aws:logs:*:*:*"
       Roles:
         - Ref: "SageMakerExecutionRole"
 
   SageMakerMSKAccessPolicy:
     Type: AWS::IAM::Policy
     Properties:
-      PolicyName: !Sub '${AWS::StackName}SageMakerMSKAccessPolicy'
+      PolicyName: !Sub "${AWS::StackName}SageMakerMSKAccessPolicy"
       PolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -559,14 +558,14 @@ Resources:
               - kafka-cluster:ReadData
               - kafka-cluster:AlterGroup
               - kafka-cluster:DescribeGroup
-            Resource: !Sub  'arn:aws:kafka:${AWS::Region}:${AWS::AccountId}:*'
+            Resource: !Sub "arn:aws:kafka:${AWS::Region}:${AWS::AccountId}:*"
       Roles:
         - Ref: "SageMakerExecutionRole"
 
   SageMakerCloudFormationAccessPolicy:
     Type: AWS::IAM::Policy
     Properties:
-      PolicyName: !Sub '${AWS::StackName}SageMakerCloudFormationAccessPolicy'
+      PolicyName: !Sub "${AWS::StackName}SageMakerCloudFormationAccessPolicy"
       PolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -574,14 +573,14 @@ Resources:
             Action:
               - cloudformation:DescribeStackResource
               - cloudformation:DescribeStacks
-            Resource: !Sub 'arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:*'
+            Resource: !Sub "arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:*"
       Roles:
         - Ref: "SageMakerExecutionRole"
 
   SageMakerS3AccessPolicy:
     Type: AWS::IAM::Policy
     Properties:
-      PolicyName: !Sub '${AWS::StackName}SageMakerS3AccessPolicy'
+      PolicyName: !Sub "${AWS::StackName}SageMakerS3AccessPolicy"
       PolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -594,14 +593,14 @@ Resources:
               - s3:DeleteObject
               - s3:DeleteObjectVersion
               - s3:DeleteObject
-            Resource: !Sub 'arn:aws:s3:::*'
+            Resource: !Sub "arn:aws:s3:::*"
       Roles:
         - Ref: "SageMakerExecutionRole"
 
   SageMakerBedrockAccessPolicy:
     Type: AWS::IAM::Policy
     Properties:
-      PolicyName: !Sub '${AWS::StackName}SageMakerBedrockAccessPolicy'
+      PolicyName: !Sub "${AWS::StackName}SageMakerBedrockAccessPolicy"
       PolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -632,14 +631,14 @@ Resources:
               - bedrock:UpdateDataSource
               - bedrock:UpdateKnowledgeBase
               - bedrock:ListKnowledgeBases
-            Resource: '*'
+            Resource: "*"
       Roles:
         - Ref: "SageMakerExecutionRole"
 
   SageMakerLambdaAccessPolicy:
     Type: AWS::IAM::Policy
     Properties:
-      PolicyName: !Sub '${AWS::StackName}SageMakerLambdaAccessPolicy'
+      PolicyName: !Sub "${AWS::StackName}SageMakerLambdaAccessPolicy"
       PolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -661,15 +660,15 @@ Resources:
               - lambda:CreateEventSourceMapping
               - lambda:UpdateFunctionConfiguration
               - lambda:GetFunctionConfiguration
-            Resource: !Sub 'arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:*'
+            Resource: !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:*"
       Roles:
         - Ref: "SageMakerExecutionRole"
 
   LambdaExecutionRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub '${AWS::StackName}LambdaExecutionRole'
-      Description: 'Lambda Execution Role'
+      RoleName: !Sub "${AWS::StackName}LambdaExecutionRole"
+      Description: "Lambda Execution Role"
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -681,13 +680,13 @@ Resources:
               - "sts:AssumeRole"
       Path: /
       Tags:
-        - Key: 'Name'
-          Value: !Join [ "", [ !Ref "AWS::StackName","LambdaExecutionRole" ] ]
+        - Key: "Name"
+          Value: !Join ["", [!Ref "AWS::StackName", "LambdaExecutionRole"]]
 
   LambdaBedrockAccessPolicy:
     Type: AWS::IAM::Policy
     Properties:
-      PolicyName: !Sub '${AWS::StackName}LambdaBedrockAccessPolicy'
+      PolicyName: !Sub "${AWS::StackName}LambdaBedrockAccessPolicy"
       PolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -717,14 +716,14 @@ Resources:
               - bedrock:UpdateAgentKnowledgeBase
               - bedrock:UpdateDataSource
               - bedrock:UpdateKnowledgeBase
-            Resource: '*'
+            Resource: "*"
       Roles:
-        - Ref: 'LambdaExecutionRole'
+        - Ref: "LambdaExecutionRole"
 
   LambdaMSKAccessPolicy:
     Type: AWS::IAM::Policy
     Properties:
-      PolicyName: !Sub '${AWS::StackName}SageMakerMSKAccessPolicy'
+      PolicyName: !Sub "${AWS::StackName}SageMakerMSKAccessPolicy"
       PolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -739,14 +738,14 @@ Resources:
               - kafka-cluster:DescribeGroup
               - kafka-cluster:DescribeClusterDynamicConfiguration
               - kafka-cluster:AlterGroup
-            Resource: !Sub  'arn:aws:kafka:${AWS::Region}:${AWS::AccountId}:*'
+            Resource: !Sub "arn:aws:kafka:${AWS::Region}:${AWS::AccountId}:*"
       Roles:
         - Ref: "LambdaExecutionRole"
 
   LambdaCloudWatchMetricsAccessPolicy:
     Type: AWS::IAM::Policy
     Properties:
-      PolicyName: !Sub '${AWS::StackName}LambdaCloudWatchMetricsAccessPolicy'
+      PolicyName: !Sub "${AWS::StackName}LambdaCloudWatchMetricsAccessPolicy"
       PolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -759,14 +758,14 @@ Resources:
               - cloudwatch:ListMetrics
               - cloudwatch:PutMetricAlarm
               - cloudwatch:PutMetricData
-            Resource: '*'
+            Resource: "*"
       Roles:
         - Ref: "LambdaExecutionRole"
 
   LambdaCloudWatchLogsAccessPolicy:
     Type: AWS::IAM::Policy
     Properties:
-      PolicyName: !Sub '${AWS::StackName}LambdaCloudWatchLogsAccessPolicy'
+      PolicyName: !Sub "${AWS::StackName}LambdaCloudWatchLogsAccessPolicy"
       PolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -785,14 +784,14 @@ Resources:
               - logs:ListLogDeliveries
               - logs:PutResourcePolicy
               - logs:UpdateLogDelivery
-            Resource: 'arn:aws:logs:*:*:*'
+            Resource: "arn:aws:logs:*:*:*"
       Roles:
         - Ref: "LambdaExecutionRole"
 
   LambdaENIAccessPolicy:
     Type: AWS::IAM::Policy
     Properties:
-      PolicyName: !Sub '${AWS::StackName}LambdaENIAccessPolicy'
+      PolicyName: !Sub "${AWS::StackName}LambdaENIAccessPolicy"
       PolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -806,11 +805,11 @@ Resources:
               - ec2:DescribeSecurityGroups
               - ec2:DescribeSubnets
               - ec2:DescribeVpcs
-            Resource: '*'
+            Resource: "*"
       Roles:
         - Ref: "LambdaExecutionRole"
 
-# Lambda Function
+  # Lambda Function
 
   KafkaConsumerLambdaFunction:
     Type: AWS::Lambda::Function
@@ -821,8 +820,8 @@ Resources:
       - LambdaMSKAccessPolicy
       - LambdaBedrockAccessPolicy
     Properties:
-      FunctionName: !Sub '${AWS::StackName}KafkaConsumerLambdaFunction'
-      Description: 'Kafka Consumer Lambda Function'
+      FunctionName: !Sub "${AWS::StackName}KafkaConsumerLambdaFunction"
+      Description: "Kafka Consumer Lambda Function - v2 exponential backoff, dynamic topic, tz-aware datetime"
       ReservedConcurrentExecutions: 1
       Handler: index.lambda_handler
       Role: !GetAtt LambdaExecutionRole.Arn
@@ -831,14 +830,15 @@ Resources:
       Layers:
         - !Ref Boto3LayerArn
       Tags:
-        - Key: 'Name'
-          Value: !Join [ "", [ !Ref "AWS::StackName","KafkaConsumerLambdaFunction" ] ]
+        - Key: "Name"
+          Value:
+            !Join ["", [!Ref "AWS::StackName", "KafkaConsumerLambdaFunction"]]
       VpcConfig:
         SecurityGroupIds:
-          - Ref: 'LambdaSecurityGroup'
+          - Ref: "LambdaSecurityGroup"
         SubnetIds:
-          - Ref: 'PrivateSubnet1'
-          - Ref: 'PrivateSubnet2'
+          - Ref: "PrivateSubnet1"
+          - Ref: "PrivateSubnet2"
       Code:
         ZipFile: !Sub
           - |
@@ -846,15 +846,38 @@ Resources:
             import json
             import base64
             import logging
+            import random
             import time
             import uuid
-            from datetime import datetime
+            from datetime import datetime, timezone
 
             import boto3
             import botocore
             from botocore.exceptions import ClientError
 
-            bedrock_agent_client = boto3.client('bedrock-agent')
+            bedrock_agent_client = boto3.client('bedrock-agent', region_name='us-east-1')
+
+            MAX_RETRIES = 5
+            BASE_DELAY = 1.0
+            MAX_DELAY = 30.0
+
+            def ingest_with_backoff(client, kb_id, ds_id, documents):
+                for attempt in range(MAX_RETRIES):
+                    try:
+                        response = client.ingest_knowledge_base_documents(
+                            knowledgeBaseId=kb_id,
+                            dataSourceId=ds_id,
+                            documents=documents
+                        )
+                        return response
+                    except botocore.exceptions.ClientError as error:
+                        error_code = error.response['Error']['Code']
+                        if error_code == 'ThrottlingException' and attempt < MAX_RETRIES - 1:
+                            delay = min(BASE_DELAY * (2 ** attempt) + random.uniform(0, 1), MAX_DELAY)
+                            print(f'ThrottlingException, retrying in {delay:.1f}s (attempt {attempt + 1}/{MAX_RETRIES})')
+                            time.sleep(delay)
+                        else:
+                            raise
 
             def lambda_handler(event, context):
                 print(f'boto3 version: {boto3.__version__}')
@@ -869,52 +892,44 @@ Resources:
                 print('## EVENT')
                 print(event)
 
-                records = event['records']['streamtopic-0']
-
-                for rec in records:
-                    # Each record has separate eventID, etc.
-                    print('## RECORD')
-                    event_payload = decode_payload(rec['value'])
-                    print('Decoded event main', event_payload)
-                    ticker = event_payload['ticker']
-                    price = event_payload['price']
-                    timestamp = event_payload['timestamp']
-                    myuuid = uuid.uuid4()
-                    print('## RECORD UUID', str(myuuid))
-                    print('## TICKER: ', ticker)
-                    print('## PRICE: ', price)
-                    payload_ts = datetime.utcfromtimestamp(timestamp).strftime('%Y-%m-%d %H:%M:%S')
-                    print('## TIMESTAMP: ', payload_ts)
-                    payload_string = "At " + payload_ts + " the price of " + ticker + " is " + str(price) + "."
-                    print('## PAYLOAD STRING: ', payload_string)
-                    time.sleep(5)
-                    try:
-                        ingest_knowledge_base_documents_response = bedrock_agent_client.ingest_knowledge_base_documents(
-                            knowledgeBaseId = kb_id,
-                            dataSourceId = ds_id,
-                            documents= [
-                                {
-                                    'content': {
-                                        'custom' : {
-                                            'customDocumentIdentifier': {
-                                                'id' : str(myuuid)
-                                            },
-                                            'inlineContent' : {
-                                                'textContent' : {
-                                                    'data' : payload_string
-                                                },
-                                                'type' : 'TEXT'
-                                            },
-                                            'sourceType' : 'IN_LINE'
+                for topic_partition, records in event['records'].items():
+                    print(f'## PROCESSING: {topic_partition}')
+                    for rec in records:
+                        print('## RECORD')
+                        event_payload = decode_payload(rec['value'])
+                        print('Decoded event main', event_payload)
+                        ticker = event_payload['ticker']
+                        price = event_payload['price']
+                        timestamp = event_payload['timestamp']
+                        myuuid = uuid.uuid4()
+                        print('## RECORD UUID', str(myuuid))
+                        print('## TICKER: ', ticker)
+                        print('## PRICE: ', price)
+                        payload_ts = datetime.fromtimestamp(timestamp, tz=timezone.utc).strftime('%Y-%m-%d %H:%M:%S')
+                        print('## TIMESTAMP: ', payload_ts)
+                        payload_string = "At " + payload_ts + " the price of " + ticker + " is " + str(price) + "."
+                        print('## PAYLOAD STRING: ', payload_string)
+                        documents = [
+                            {
+                                'content': {
+                                    'custom' : {
+                                        'customDocumentIdentifier': {
+                                            'id' : str(myuuid)
                                         },
-                                        'dataSourceType' : 'CUSTOM'
-                                    }
+                                        'inlineContent' : {
+                                            'textContent' : {
+                                                'data' : payload_string
+                                            },
+                                            'type' : 'TEXT'
+                                        },
+                                        'sourceType' : 'IN_LINE'
+                                    },
+                                    'dataSourceType' : 'CUSTOM'
                                 }
-                            ]
-                        )
-                        print('## INGEST KNOWLEDGE BASE DOCUMENTS RESPONSE: ', ingest_knowledge_base_documents_response)
-                    except botocore.exceptions.ClientError as error:
-                        raise error
+                            }
+                        ]
+                        response = ingest_with_backoff(bedrock_agent_client, kb_id, ds_id, documents)
+                        print('## INGEST KNOWLEDGE BASE DOCUMENTS RESPONSE: ', response)
 
                 return {
                     'statusCode': 200,
@@ -931,7 +946,7 @@ Resources:
                 return event_payload
           - Region: !Ref AWS::Region
 
-# MSK Cluster
+  # MSK Cluster
 
   MSKLogGroup:
     Type: AWS::Logs::LogGroup
@@ -951,7 +966,7 @@ Resources:
         StorageInfo:
           EBSStorageInfo:
             VolumeSize: 5
-      ClusterName: !Sub '${AWS::StackName}MSKCluster'
+      ClusterName: !Sub "${AWS::StackName}MSKCluster"
       LoggingInfo:
         BrokerLogs:
           CloudWatchLogs:
@@ -969,7 +984,7 @@ Resources:
         Unauthenticated:
           Enabled: true
 
-# SageMaker Studio
+  # SageMaker Studio
 
   StudioDomain:
     Type: AWS::SageMaker::Domain
@@ -995,7 +1010,7 @@ Resources:
         SecurityGroups: [!Ref SageMakerSecurityGroup]
         StudioWebPortal: ENABLED
         DefaultLandingUri: "studio::"
-      DomainName: !Sub '${AWS::StackName}SageMakerStudioDomain'
+      DomainName: !Sub "${AWS::StackName}SageMakerStudioDomain"
       DomainSettings:
         SecurityGroupIds:
           - !Ref SageMakerSecurityGroup
@@ -1009,7 +1024,7 @@ Resources:
       SubnetIds:
         - !Ref PrivateSubnet1
         - !Ref PrivateSubnet2
-      VpcId: !Ref 'VPC'
+      VpcId: !Ref "VPC"
 
   UserProfile:
     Type: AWS::SageMaker::UserProfile
@@ -1017,9 +1032,9 @@ Resources:
       - StudioDomain
     Properties:
       DomainId: !GetAtt StudioDomain.DomainId
-      UserProfileName: !Sub '${AWS::StackName}SageMakerUserProfile'
+      UserProfileName: !Sub "${AWS::StackName}SageMakerUserProfile"
       UserSettings:
-        DefaultLandingUri: 'studio::'
+        DefaultLandingUri: "studio::"
         ExecutionRole: !GetAtt SageMakerExecutionRole.Arn
         SecurityGroups: [!Ref SageMakerSecurityGroup]
 


### PR DESCRIPTION
## Summary

Implements batch processing and configurable rate limiting to prevent Bedrock API throttling (ThrottlingException) when ingesting documents from Kafka stream.

Closes #5

## Changes

### Lambda Function Code (`templates/bedrock-kb-stream-ingest.yml`)

1. **Batch Processing**
   - Collect all documents from Kafka records first
   - Process in batches of up to 10 documents per API call
   - Reduces API call count by ~10x

2. **Rate Limiting**
   - Add `BATCH_DELAY` constant (default: 2.0 seconds)
   - Insert `time.sleep(BATCH_DELAY)` between batches (except last batch)
   - Configurable via environment variable for runtime tuning

3. **Code Optimization**
   - Consolidate verbose per-record logging to single line: `print(f'## DOC {myuuid}: {payload_string}')`
   - Remove redundant environment variable logging
   - Code size: 3,562 bytes (within 4,096 byte limit, 534 bytes remaining)

4. **Version Update**
   - Lambda Description: v2 → v3 "batch processing with rate limiting"

### Documentation Updates

#### CLAUDE.md
- **Lambda Function Code section**: Add batch processing and rate limiting explanation
  - Batches up to 10 documents per API call (API limit)
  - Implements rate limiting with `BATCH_DELAY` environment variable (default: 2.0s)
  - Notes API constraints: 5 RPS, 10 documents/request
- **Environment Variables section**: Add `BATCH_DELAY` (optional)

#### docs/plan-avoid-throttling.md (new)
- Detailed implementation plan with phase-by-phase TODO checklist
- Reference project analysis and tuning results
- API constraints and practical rate limits
- Code size management strategy

## Technical Details

### API Constraints
- **IngestKnowledgeBaseDocuments**: 5 RPS (fixed), 10 documents/request max
- **Practical limit**: ~0.5 TPS (based on reference project testing)

### Effect Estimation

For 17 records (TestData.csv):

| Metric | Before | After |
|--------|--------|-------|
| API calls | 17 | 2 |
| Processing time | ~few seconds + throttling delays | ~2.0s (1 interval) |

For 100 records (MSK BatchSize default):

| Metric | Before | After |
|--------|--------|-------|
| API calls | 100 | 10 |
| Effective rate | Uncontrolled → throttling | 0.5 TPS |
| Processing time | Unstable (throttling + retries) | ~20s + API response |

## Testing Plan

### Deployment

```bash
aws cloudformation update-stack \
  --stack-name BedrockStreamIngest \
  --template-body file://templates/bedrock-kb-stream-ingest.yml \
  --parameters ParameterKey=Boto3LayerArn,ParameterValue=<EXISTING_ARN> \
  --capabilities CAPABILITY_NAMED_IAM

aws cloudformation wait stack-update-complete --stack-name BedrockStreamIngest
```

### Verification

1. Run `notebooks/2.StreamIngest.ipynb` to send TestData.csv (17 records) to MSK
2. Check CloudWatch Logs for Lambda execution:
   - ✓ `BATCH_DELAY: 2.0` logged
   - ✓ `## TOTAL DOCUMENTS: 17` logged
   - ✓ `## INGESTING BATCH 1/2 (10 docs)` logged
   - ✓ `## INGESTING BATCH 2/2 (7 docs)` logged
   - ✓ No ThrottlingException retry logs
   - ✓ Successful completion (statusCode: 200)
3. Verify 17 documents ingested into Bedrock Knowledge Base

### Tuning (if needed)

If throttling still occurs, increase `BATCH_DELAY`:

```bash
aws lambda update-function-configuration \
  --function-name BedrockStreamIngestKafkaConsumerLambdaFunction \
  --environment "Variables={KBID=<KB_ID>,DSID=<DS_ID>,BATCH_DELAY=3.0}"
```

## Commits

- f4b4eec feat(lambda): implement batch processing and rate limiting to avoid throttling
- 54304f4 docs: add implementation plan for throttling avoidance
- 8271fbc docs: update plan-avoid-throttling.md with Phase 4 and 5 completion status

🤖 Generated with [Claude Code](https://claude.com/claude-code)