### PR TITLE
chore: clean up notebook and upgrade Kafka to 3.9.x

### DIFF
--- a/notebooks/1.Setup.ipynb
+++ b/notebooks/1.Setup.ipynb
@@ -43,6 +43,7 @@
    },
    "outputs": [],
    "source": [
+    "# Set the stack name and Kafka topic name\n",
     "StackName = 'BedrockStreamIngest'\n",
     "KafkaTopic = 'streamtopic'"
    ]
@@ -100,7 +101,7 @@
     "        StackName = StackName,\n",
     "        LogicalResourceId = 'MSKCluster'\n",
     "    )\n",
-    "    \n",
+    "\n",
     "    MSKClusterArn = describe_stack_resource_response['StackResourceDetail']['PhysicalResourceId']\n",
     "    print('MSK Cluster ARN:', MSKClusterArn)\n",
     "\n",
@@ -128,7 +129,7 @@
     "    )\n",
     "    BootstrapBrokerString = get_bootstrap_brokers_response['BootstrapBrokerString']\n",
     "    print(BootstrapBrokerString)\n",
-    "    \n",
+    "\n",
     "except botocore.exceptions.ClientError as error:\n",
     "    print(error)\n",
     "    raise error"
@@ -202,23 +203,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "787bb6d6-0d1f-436a-9efb-e46e496c94b9",
-   "metadata": {},
-   "source": [
-    "Create a Bedrock Knowledge Base via the AWS console\n",
-    "\n",
-    "- Navigate to \"Knowledge Bases\" page within Amazon Bedrock service AWS console page.\n",
-    "- Find the \"Create\" button and choose \"Knowledge Base with vector store\" option.\n",
-    "- For \"Knowledge Base name\", use the value from KBName variable printed above (default: BedrockStreamIngestKnowledgeBase)\n",
-    "- For Data Source, choose \"Custom\".\n",
-    "- In Data Source configuration page, use the value from DSName variable printed above (default: BedrockStreamIngestKBCustomDS)\n",
-    "- For Embeddings Model, choose \"Titan Text Embeddings v2\"\n",
-    "- Leave the rest as defaults and hit \"Create Knowledge Base\" button.\n",
-    "- Wait until the Knowledge Base is created."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "id": "f0e4bd24-8a61-4aaa-96b3-8666a28234bc",
@@ -235,9 +219,9 @@
     "    list_knowledge_bases_response = bedrock_agent_client.list_knowledge_bases(\n",
     "        maxResults=100\n",
     "    )\n",
-    "   \n",
+    "\n",
     "    for knowledge_base in list_knowledge_bases_response['knowledgeBaseSummaries']:\n",
-    "        if KBName in knowledge_base['name']: \n",
+    "        if KBName in knowledge_base['name']:\n",
     "            KBId = knowledge_base['knowledgeBaseId']\n",
     "\n",
     "except botocore.exceptions.ClientError as error:\n",
@@ -264,15 +248,15 @@
     "    list_data_sources_response = bedrock_agent_client.list_data_sources(\n",
     "        knowledgeBaseId = KBId\n",
     "    )\n",
-    "  \n",
+    "\n",
     "    for data_source in list_data_sources_response['dataSourceSummaries']:\n",
-    "        if DSName in data_source['name']: \n",
+    "        if DSName in data_source['name']:\n",
     "            DSId = data_source['dataSourceId']\n",
     "\n",
     "except botocore.exceptions.ClientError as error:\n",
     "    print(error)\n",
     "    raise error\n",
-    "    \n",
+    "\n",
     "print(DSId)"
    ]
   },
@@ -294,7 +278,7 @@
     "        StackName = StackName,\n",
     "        LogicalResourceId = 'KafkaConsumerLambdaFunction'\n",
     "    )\n",
-    "    \n",
+    "\n",
     "    LambdaFunctionName = describe_stack_resource_response['StackResourceDetail']['PhysicalResourceId']\n",
     "    print('Lambda Function Name:', LambdaFunctionName)\n",
     "\n",
@@ -327,7 +311,7 @@
     "        }\n",
     "    )\n",
     "    print(update_function_configuration_response)\n",
-    "    \n",
+    "\n",
     "except botocore.exceptions.ClientError as error:\n",
     "    print(error)\n",
     "    raise error"
@@ -411,9 +395,9 @@
     "    except botocore.exceptions.ClientError as error:\n",
     "        print(error)\n",
     "        raise error\n",
-    "    \n",
+    "\n",
     "    if status == \"Enabled\" or status == \"Disabled\":\n",
-    "        break        \n",
+    "        break\n",
     "    time.sleep(30)"
    ]
   },

--- a/templates/bedrock-kb-stream-ingest.yml
+++ b/templates/bedrock-kb-stream-ingest.yml
@@ -969,8 +969,8 @@ Resources:
           ClientBroker: TLS_PLAINTEXT
           InCluster: false
       EnhancedMonitoring: DEFAULT
-      # Kafka 3.8.x is the AWS recommended version as documented in Supported Apache Kafka versions(https://docs.aws.amazon.com/msk/latest/developerguide/supported-kafka-versions.html).
-      KafkaVersion: 3.8.x
+      # Kafka 3.9.x is the AWS recommended version as documented in Supported Apache Kafka versions(https://docs.aws.amazon.com/msk/latest/developerguide/supported-kafka-versions.html).
+      KafkaVersion: 3.9.x
       NumberOfBrokerNodes: 2
       ClientAuthentication:
         Unauthenticated:


### PR DESCRIPTION
## Summary

- Remove the manual Bedrock Knowledge Base creation markdown cell from `1.Setup.ipynb` (KB is assumed to already exist).
- Strip trailing whitespace across several notebook cells.
- Update MSK Kafka version from `3.8.x` to `3.9.x` in the CloudFormation template.

## Test plan

- [ ] Verify `1.Setup.ipynb` parses as valid JSON and renders correctly.
- [ ] Confirm `templates/bedrock-kb-stream-ingest.yml` passes CloudFormation validation.

Made with [Cursor](https://cursor.com)